### PR TITLE
Fix memory accounting bug in bnfa_free

### DIFF
--- a/src/aho_corasick.h
+++ b/src/aho_corasick.h
@@ -628,7 +628,7 @@ void AhoCorasickSearch::bnfa_free(T* p, size_t n, size_t& m)
             delete[] p;
         else
             delete p;
-        m -= n;
+        m -= n * sizeof(T);
     }
 }
 template <typename T>
@@ -638,7 +638,7 @@ void AhoCorasickSearch::bnfa_free(T* p, size_t& m)
     if (p)
     {
         delete p;
-        --m;
+        m -= sizeof(T);
     }
 }
 


### PR DESCRIPTION
## Summary
- fix bookkeeping of memory usage in `bnfa_free` by subtracting the actual bytes freed

## Testing
- `g++ -std=c++11 -DNO_BOOST -I./src -c src/aho_corasick.cc -o aho_corasick.o` *(fails: flexible array member in union)*

------
https://chatgpt.com/codex/tasks/task_e_6859189a7ab4832abdc19d37c92359c4