### PR TITLE
Fix typo in aho_corasick comments

### DIFF
--- a/src/aho_corasick.cc
+++ b/src/aho_corasick.cc
@@ -86,7 +86,7 @@
 ** instruction pipelining.  Aren't we all.  To this end, the number of
 ** patterns, length of search text, and cpu cache L1,L2,L3 all affect
 ** performance. The relative performance of the sparse and full format NFA and
-** DFA varies as you vary the pattern charactersitics,and search text length,
+** DFA varies as you vary the pattern characteristics,and search text length,
 ** but strong performance trends are present and stable.
 **
 **


### PR DESCRIPTION
## Summary
- fix spelling of 'charactersitics' in comment

## Testing
- `g++ -std=c++11 -c src/aho_corasick.cc -o /tmp/aho.o` *(fails: boost headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_68591f4f4510832a86f695cbf1edf73a