### PR TITLE
Fix trailing comment artifact in header

### DIFF
--- a/src/aho_corasick.h
+++ b/src/aho_corasick.h
@@ -37,7 +37,6 @@
 ** along with this program; if not, write to the Free Software
 ** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
 ** USA
-k**
 */
 #pragma once
 


### PR DESCRIPTION
## Summary
- remove stray `k**` line from comment

## Testing
- `g++ -c src/aho_corasick.cc -o /tmp/aho.o` *(fails: boost header missing)*
- `g++ -DNO_BOOST -c src/aho_corasick.cc -o /tmp/aho.o` *(fails: flexible array member)*

------
https://chatgpt.com/codex/tasks/task_e_68591f6047c4832abfae6b57e2360594