### PR TITLE
Switch pattern userdata to std::any

### DIFF
--- a/src/aho_corasick.h
+++ b/src/aho_corasick.h
@@ -47,10 +47,8 @@
 #include <stdint.h>
 #include <set>
 #include <algorithm>
+#include <any>
 
-#ifndef NO_BOOST
-#include <boost/any.hpp>
-#endif
 
 #include "uppercase_iterator.h"
 
@@ -78,11 +76,7 @@ namespace textsearch {
 */
 class AhoCorasickSearch {
 public:
-#ifndef NO_BOOST
-    typedef boost::any any_t;
-#else
-    typedef const void* any_t;
-#endif
+    using any_t = std::any;
     typedef int(*match_function_ptr_t)(any_t pattern_userdata, int index, any_t search_userdata);
 #ifdef BNFA_STATE_64BITS
     typedef uint64_t bnfa_state_t;


### PR DESCRIPTION
## Summary
- modernize user data handling by including `<any>`
- define `any_t` as an alias to `std::any`

## Testing
- `g++ -std=c++17 -I./src -c src/aho_corasick.cc -o /tmp/test.o` *(fails: flexible array member in union)*

------
https://chatgpt.com/codex/tasks/task_e_685923f5477c832abedc6ce9fe2aafc4