### PR TITLE
Switch bnfa case enum to scoped class

### DIFF
--- a/src/aho_corasick.cc
+++ b/src/aho_corasick.cc
@@ -353,7 +353,7 @@ AhoCorasickSearch::_bnfa_add_pattern_states(bnfa_pattern_t * p) {
     *  Match up pattern with existing states
     */
     for (; n > 0; pattern++, n--) {
-        if (bnfaCaseMode == BNFA_CASE)
+        if (bnfaCaseMode == bnfa_case::BNFA_CASE)
             next = _bnfa_list_get_next_state(state, *pattern);
         else
             next = _bnfa_list_get_next_state(state, toupper_functor(*pattern));
@@ -372,7 +372,7 @@ AhoCorasickSearch::_bnfa_add_pattern_states(bnfa_pattern_t * p) {
     {
         bnfaNumStates++;
 
-        if (bnfaCaseMode == BNFA_CASE)
+        if (bnfaCaseMode == bnfa_case::BNFA_CASE)
         {
             if (_bnfa_list_put_next_state(state, *pattern, bnfaNumStates) < 0)
                 return -1;
@@ -925,7 +925,7 @@ void AhoCorasickSearch::print()
 /*
 *  Create a new AC state machine
 */
-AhoCorasickSearch::AhoCorasickSearch(bnfa_enum_case_t flag)
+AhoCorasickSearch::AhoCorasickSearch(bnfa_case flag)
     :toupper_functor(toupper)
 {
     bnfaPatterns = 0;
@@ -942,7 +942,7 @@ AhoCorasickSearch::AhoCorasickSearch(bnfa_enum_case_t flag)
 
     bnfaPatternCnt = 0;
     bnfaOptimizeFailureStates = false;
-    bnfaCaseMode = BNFA_PER_PAT_CASE;
+    bnfaCaseMode = bnfa_case::BNFA_PER_PAT_CASE;
     bnfaFormat = BNFA_SPARSE;
     bnfaAlphabetSize = BNFA_MAX_ALPHABET_SIZE;
 
@@ -964,11 +964,11 @@ AhoCorasickSearch::setOptimizeFailureStates(bool flag)
 }
 
 void
-AhoCorasickSearch::setCase(bnfa_enum_case_t flag)
+AhoCorasickSearch::setCase(bnfa_case flag)
 {
-    if (flag == BNFA_PER_PAT_CASE) bnfaCaseMode = flag;
-    if (flag == BNFA_CASE) bnfaCaseMode = flag;
-    if (flag == BNFA_NOCASE) bnfaCaseMode = flag;
+    if (flag == bnfa_case::BNFA_PER_PAT_CASE) bnfaCaseMode = flag;
+    if (flag == bnfa_case::BNFA_CASE) bnfaCaseMode = flag;
+    if (flag == bnfa_case::BNFA_NOCASE) bnfaCaseMode = flag;
 }
 
 /*

--- a/src/aho_corasick.h
+++ b/src/aho_corasick.h
@@ -91,16 +91,16 @@ public:
     typedef uint32_t bnfa_state_t;
     typedef uint_least32_t bnfa_state_index_t;
 #endif
-    typedef enum {
+    enum class bnfa_case : int {
         BNFA_PER_PAT_CASE, // DEFAULT:case-sensitivity is specified per pattern
         BNFA_CASE,         // binary search (case sensitive), fastest mode
-        BNFA_NOCASE        // case-insensitive search 
-    } bnfa_enum_case_t;
-    
-    void setCase(bnfa_enum_case_t flag);
+        BNFA_NOCASE        // case-insensitive search
+    };
+
+    void setCase(bnfa_case flag);
 
 
-    explicit AhoCorasickSearch(bnfa_enum_case_t flag = BNFA_CASE);
+    explicit AhoCorasickSearch(bnfa_case flag = bnfa_case::BNFA_CASE);
     ~AhoCorasickSearch();
     
     void setOptimizeFailureStates(bool flag=true);
@@ -285,7 +285,7 @@ private:
     typedef struct bnfa_match_s bnfa_match_t;
 
     int                bnfaMethod;
-    int                bnfaCaseMode;
+    bnfa_case          bnfaCaseMode;
     int                bnfaFormat;
     unsigned           bnfaAlphabetSize;
     bool               bnfaOptimizeFailureStates;
@@ -474,7 +474,7 @@ AhoCorasickSearch::search(RAIterator begin, RAIterator end,
         sindex = *current_state;
     }
 
-    if (bnfaCaseMode == BNFA_PER_PAT_CASE)
+    if (bnfaCaseMode == bnfa_case::BNFA_PER_PAT_CASE)
     {
         functor_iterator<character_functor, RAIterator> itBegin(toupper_functor, begin);
         functor_iterator<character_functor, RAIterator> itEnd(toupper_functor, end);
@@ -501,7 +501,7 @@ AhoCorasickSearch::search(RAIterator begin, RAIterator end,
                 );
         }
     }
-    else if (bnfaCaseMode == BNFA_CASE)
+    else if (bnfaCaseMode == bnfa_case::BNFA_CASE)
     {
         ret = _bnfa_search_csparse_nfa_case(
             begin, 


### PR DESCRIPTION
## Summary
- use `enum class bnfa_case` to scope case mode constants
- update state machine to use the scoped enum

## Testing
- `clang++ -std=c++17 -DNO_BOOST -c src/aho_corasick.cc -I src`

------
https://chatgpt.com/codex/tasks/task_e_6859242eaa48832ab5783a9d883cf091