### PR TITLE
Fix flexible array inside union

### DIFF
--- a/src/aho_corasick.cc
+++ b/src/aho_corasick.cc
@@ -282,7 +282,9 @@ int AhoCorasickSearch::_bnfa_list_free_table() {
     }
 
     if (bnfaTransTable) {
-        bnfa_free(bnfaTransTable, bnfaMaxStates, list_memory);
+        free(bnfaTransTable);
+        list_memory -= sizeof(bnfa_trans_table_t) +
+                       (bnfaMaxStates - 1) * sizeof(void*);
         bnfaTransTable = 0;
     }
 
@@ -1036,12 +1038,14 @@ AhoCorasickSearch::compile()
     /* Alloc a List based State Transition table */
     /* C variable struct size idiom */
     bnfaTransTable = reinterpret_cast<bnfa_trans_table_t*>(
-        calloc(bnfaMaxStates, sizeof(void*)));
+        calloc(1, sizeof(bnfa_trans_table_t) +
+               (bnfaMaxStates - 1) * sizeof(void*)));
     if (!bnfaTransTable)
     {
         return -1;
     }
-    list_memory += bnfaMaxStates * sizeof(void*);
+    list_memory += sizeof(bnfa_trans_table_t) +
+                   (bnfaMaxStates - 1) * sizeof(void*);
 
     /*
     ** Alloc a MatchList table -

--- a/src/aho_corasick.h
+++ b/src/aho_corasick.h
@@ -299,10 +299,8 @@ private:
     unsigned           bnfaMatchStates;
 
     typedef struct bnfa_trans_table {
-        union {
-            bnfa_state_t* states;
-            bnfa_trans_node_t* transitions[]; // transitions[0] => states
-        };
+        bnfa_state_t* states;
+        bnfa_trans_node_t* transitions[]; // transitions[0] was states in union
     } bnfa_trans_table_t;
 
     bnfa_trans_table_t  * bnfaTransTable;


### PR DESCRIPTION
## Summary
- remove union around the transition table flexible array
- allocate/free `bnfa_trans_table_t` with correct size

## Testing
- `g++ -std=c++11 -DNO_BOOST -c src/aho_corasick.cc -o /tmp/aho.o`
- `g++ -std=c++11 -DNO_BOOST -Wall -Wextra -c src/aho_corasick.cc -o /tmp/aho.o`

------
https://chatgpt.com/codex/tasks/task_e_6859239a1238832aa8fbd9bc756529e4