### PR TITLE
Use signed return for list row conversion

### DIFF
--- a/src/aho_corasick.cc
+++ b/src/aho_corasick.cc
@@ -151,6 +151,7 @@
 #include <string.h>
 #include <ctype.h>
 #include <stdarg.h>
+#include <cstddef>
 
 #include <deque>
 
@@ -293,7 +294,7 @@ int AhoCorasickSearch::_bnfa_list_free_table() {
 /*
 * Converts a single row of states from list format to a full format
 */
-size_t
+ptrdiff_t
 AhoCorasickSearch::_bnfa_list_conv_row_to_full(
     bnfa_state_index_t state,
     bnfa_state_t * full ) {
@@ -312,7 +313,7 @@ AhoCorasickSearch::_bnfa_list_conv_row_to_full(
         } else {
             memset(full, 0, sizeof(bnfa_state_t)*bnfaAlphabetSize);
         }
-        return bnfaAlphabetSize;
+        return static_cast<ptrdiff_t>(bnfaAlphabetSize);
     } else {
         int tcnt = 0;
 
@@ -329,7 +330,7 @@ AhoCorasickSearch::_bnfa_list_conv_row_to_full(
             tcnt++;
             t = t->next;
         }
-        return tcnt;
+        return static_cast<ptrdiff_t>(tcnt);
     }
 }
 
@@ -616,7 +617,10 @@ AhoCorasickSearch::_bnfa_conv_list_to_csparse_array()
 
         /* count transitions */
         nc = 0;
-        _bnfa_list_conv_row_to_full(k, full);
+        if (_bnfa_list_conv_row_to_full(k, full) < 0)
+        {
+            return -1;
+        }
         for (i = 0; i<bnfaAlphabetSize; i++)
         {
             state = fullGetTransitionState(full[i]);
@@ -687,7 +691,10 @@ AhoCorasickSearch::_bnfa_conv_list_to_csparse_array()
         ps_index++;  /* skip past state word */
 
         /* conver state 'k' to full format */
-        _bnfa_list_conv_row_to_full(k, full);
+        if (_bnfa_list_conv_row_to_full(k, full) < 0)
+        {
+            return -1;
+        }
 
         /* count transitions */
         nc = 0;
@@ -715,7 +722,10 @@ AhoCorasickSearch::_bnfa_conv_list_to_csparse_array()
             ps_index++;
 
             /* copy the transitions */
-            _bnfa_list_conv_row_to_full(k, &ps[ps_index]);
+            if (_bnfa_list_conv_row_to_full(k, &ps[ps_index]) < 0)
+            {
+                return -1;
+            }
 
             ps_index += BNFA_MAX_ALPHABET_SIZE;  /* add in 256 transitions */
 

--- a/src/aho_corasick.h
+++ b/src/aho_corasick.h
@@ -45,6 +45,7 @@
 
 #include <limits.h>
 #include <stdint.h>
+#include <cstddef>
 #include <set>
 #include <algorithm>
 
@@ -345,7 +346,7 @@ private:
     bnfa_state_index_t 
         _bnfa_list_get_next_state(bnfa_state_index_t state, unsigned char input);
 
-    size_t _bnfa_list_conv_row_to_full(bnfa_state_index_t state, bnfa_state_t * full);
+    ptrdiff_t _bnfa_list_conv_row_to_full(bnfa_state_index_t state, bnfa_state_t * full);
     int _bnfa_add_pattern_states(bnfa_pattern_t * p);
     int _bnfa_opt_nfa();
     int _bnfa_build_nfa();


### PR DESCRIPTION
## Summary
- add `<cstddef>` include for `ptrdiff_t`
- return `ptrdiff_t` from `_bnfa_list_conv_row_to_full`
- check for negative return when converting rows

## Testing
- `g++ -std=c++17 -DNO_BOOST -c src/aho_corasick.cc -I src` *(fails: flexible array member in union)*

------
https://chatgpt.com/codex/tasks/task_e_68592425de7c832ab2cf93153cf0c013