### PR TITLE
Fix C++17 requirement propagation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,9 @@ add_library(aho_corasick_search
     src/aho_corasick.cc
 )
 
+# Require C++17 for the library and propagate to dependents
+target_compile_features(aho_corasick_search PUBLIC cxx_std_17)
+
 # Public include directory
 target_include_directories(aho_corasick_search
     PUBLIC

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The code is released under the terms of the **GNU General Public License version
 
 ## Building
 
-All sources are located under the `src/` directory. To build your own program that links against the library you only need a C++11 compiler. The example below compiles `example.cpp` together with the library sources:
+All sources are located under the `src/` directory. To build your own program that links against the library you need a C++17-capable compiler. The example below compiles `example.cpp` together with the library sources:
 
 ```sh
 g++ -std=c++17 -O2 example.cpp src/aho_corasick.cc -o example


### PR DESCRIPTION
## Summary
- ensure the library enforces C++17 features and propagates that requirement to dependents
- clarify README that a C++17-capable compiler is required

## Testing
- `cmake .. -DBUILD_EXAMPLES=ON -DBUILD_TESTS=ON`
- `cmake --build .`
- `ctest --rerun-failed --output-on-failure` *(fails: basic - Segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_e_6859402d5a10832abfce376271e655fe