### PR TITLE
Ignore build directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@
 *.exe
 *.out
 *.app
+
+# Temporary build directories
+build*/
+/build*/


### PR DESCRIPTION
## Summary
- extend `.gitignore` to skip temporary build directories

## Testing
- `cmake .. -DBUILD_TESTS=ON`
- `cmake --build .`
- `ctest` *(fails: basic - SegFault)*

------
https://chatgpt.com/codex/tasks/task_e_68594636b0c8832abf8e8e5e9c1248a2