### PR TITLE
Add VSCode build/debug config for tests

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,33 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Debug Example",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/example",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}",
+            "environment": [],
+            "preLaunchTask": "build example",
+            "MIMode": "gdb",
+            "miDebuggerPath": "gdb",
+            "externalConsole": false
+        },
+        {
+            "name": "Debug test_basic",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/test_basic",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}",
+            "environment": [],
+            "preLaunchTask": "build test_basic",
+            "MIMode": "gdb",
+            "miDebuggerPath": "gdb",
+            "externalConsole": false
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,42 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build example",
+            "type": "shell",
+            "command": "g++",
+            "args": [
+                "-std=c++17",
+                "-g",
+                "-Isrc",
+                "examples/example.cpp",
+                "src/aho_corasick.cc",
+                "-o",
+                "example"
+            ],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "problemMatcher": ["$gcc"]
+        },
+        {
+            "label": "build test_basic",
+            "type": "shell",
+            "command": "g++",
+            "args": [
+                "-std=c++17",
+                "-g",
+                "-Isrc",
+                "tests/test_basic.cpp",
+                "src/aho_corasick.cc",
+                "-o",
+                "test_basic"
+            ],
+            "group": {
+                "kind": "build"
+            },
+            "problemMatcher": ["$gcc"]
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -49,3 +49,11 @@ int main() {
 ```
 
 See the source files under `src/` for additional details and advanced usage.
+
+## Visual Studio Code
+
+This repository includes tasks for building and debugging the example
+program. Run `Ctrl+Shift+B` to compile it or start the **Debug Example**
+configuration to launch it under the debugger. A similar **Debug test_basic**
+configuration and `build test_basic` task are provided for debugging the unit
+test.


### PR DESCRIPTION
## Summary
- add task to compile `tests/test_basic.cpp`
- add launch configuration to debug `test_basic`
- document new VSCode task and launch support

## Testing
- `g++ -std=c++17 -g -Isrc examples/example.cpp src/aho_corasick.cc -o example`
- `g++ -std=c++17 -g -Isrc tests/test_basic.cpp src/aho_corasick.cc -o test_basic`


------
https://chatgpt.com/codex/tasks/task_e_68595c8d28c0832a8f7f79355c12a725