### PR TITLE
Fix search state and streaming safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,18 @@ int main() {
 
 See the source files under `src/` for additional details and advanced usage.
 
+## Streaming searches
+
+For searches split across multiple buffers, pass the same non-null
+`bnfa_state_index_t` state pointer to each `search()` call. A null state pointer
+is supported for single-buffer searches.
+
+In `BNFA_PER_PAT_CASE` mode, case-sensitive patterns that start in a previous
+buffer and end in the current buffer are not reported because the API only
+carries automaton state across calls, not the previous bytes required for exact
+case verification. Use `BNFA_CASE`, `BNFA_NOCASE`, or per-pattern `nocase=true`
+when cross-buffer matches are required.
+
 ## Visual Studio Code
 
 This repository includes tasks for building and debugging the example

--- a/src/aho_corasick.cc
+++ b/src/aho_corasick.cc
@@ -559,7 +559,7 @@ AhoCorasickSearch::_bnfa_build_nfa()
                 px = bnfa_alloc(matchlist_memory, (bnfa_match_node_t*)0);
                 if (!px)
                 {
-                    return 0;
+                    return -1;
                 }
 
                 px->data = mlist->data;
@@ -991,7 +991,7 @@ AhoCorasickSearch::~AhoCorasickSearch()
     bnfa_pattern_t * patrn, *ipatrn;
     bnfa_match_node_t   * mlist, *ilist;
 
-    for (i = 0; i < bnfaNumStates; i++)
+    for (i = 0; bnfaMatchList && i < bnfaNumStates; i++)
     {
         /* free match list entries */
         mlist = bnfaMatchList[i];
@@ -1005,6 +1005,8 @@ AhoCorasickSearch::~AhoCorasickSearch()
         bnfaMatchList[i] = 0;
 
     }
+
+    _bnfa_list_free_table();
 
     /* Free patterns */
     patrn = bnfaPatterns;
@@ -1077,7 +1079,10 @@ AhoCorasickSearch::compile()
     bnfaNumStates = 0;
     for (plist = bnfaPatterns; plist != nullptr; plist = plist->next)
     {
-        _bnfa_add_pattern_states(plist);
+        if (_bnfa_add_pattern_states(plist))
+        {
+            return -1;
+        }
     }
     bnfaNumStates++; 
 
@@ -1089,19 +1094,20 @@ AhoCorasickSearch::compile()
     /* ReAlloc a smaller MatchList table -  only need NumStates  */
     tmpMatchList = bnfaMatchList;
 
-    bnfaMatchList = bnfa_alloc(
+    bnfa_match_node_t** resizedMatchList = bnfa_alloc(
         bnfaNumStates,
         matchlist_memory,
         (bnfa_match_node_t**)0
         );
-    if (!bnfaMatchList)
+    if (!resizedMatchList)
     {
         return -1;
     }
 
-    memcpy(bnfaMatchList, tmpMatchList, sizeof(bnfa_match_node_t**) * bnfaNumStates);
+    memcpy(resizedMatchList, tmpMatchList, sizeof(bnfa_match_node_t**) * bnfaNumStates);
 
     bnfa_free(tmpMatchList, bnfaMaxStates, matchlist_memory);
+    bnfaMatchList = resizedMatchList;
 
     /* Alloc a failure state table -  only need NumStates */
     bnfaFailState = bnfa_alloc(bnfaNumStates, failstate_memory, (bnfa_state_index_t*)0);

--- a/src/aho_corasick.h
+++ b/src/aho_corasick.h
@@ -49,6 +49,7 @@
 #include <set>
 #include <algorithm>
 #include <any>
+#include <iterator>
 
 
 #include "uppercase_iterator.h"
@@ -118,7 +119,11 @@ public:
         );
 
     int compile();
-    
+
+    // current_state is optional for single-buffer searches. Pass the same
+    // non-null state pointer across calls to continue matching across buffers.
+    // In BNFA_PER_PAT_CASE, case-sensitive patterns that begin before the
+    // current buffer cannot be exact-case verified and are not reported.
     template<typename RAIterator>
     unsigned search(RAIterator begin, RAIterator end,
         match_function_ptr_t match,
@@ -248,21 +253,31 @@ private:
         match_function_functor_check(
             match_function_ptr_t userfunc, 
             RAIterator begin, 
+            RAIterator end,
             bool check=false
-            ) : userfunc_(userfunc), begin_(begin),check_(check) {}
+            ) : userfunc_(userfunc), begin_(begin), end_(end), check_(check) {}
         int operator() (
             any_t pattern_userdata, 
             int index, 
             any_t search_userdata, 
-            bnfa_pattern_t* pattern
+            bnfa_pattern_t* pattern,
+            bool starts_before_buffer=false
             )
         {
             if (check_ && !pattern->nocase)
             {
+                if (starts_before_buffer || index < 0)
+                    return 0;
+
+                RAIterator pattern_begin = begin_ + index;
+                using difference_type = typename std::iterator_traits<RAIterator>::difference_type;
+                if (end_ - pattern_begin < static_cast<difference_type>(pattern->n))
+                    return 0;
+
                 if (std::equal(
                         pattern->casepatrn,
                         pattern->casepatrn+pattern->n,
-                        begin_ +index
+                        pattern_begin
                         )
                     )
                     return userfunc_(pattern_userdata, index, search_userdata);
@@ -274,6 +289,7 @@ private:
     private:
         match_function_ptr_t userfunc_;
         RAIterator begin_;
+        RAIterator end_;
         bool check_;
     };
 
@@ -477,7 +493,7 @@ AhoCorasickSearch::search(RAIterator begin, RAIterator end,
             ret = _bnfa_search_csparse_nfa_case(
                 itBegin, 
                 itEnd, 
-                match_function_functor_check<RAIterator>(Match,begin,true),
+                match_function_functor_check<RAIterator>(Match, begin, end, true),
                 userdata, 
                 local_state,
                 &local_state
@@ -488,7 +504,7 @@ AhoCorasickSearch::search(RAIterator begin, RAIterator end,
             ret = _bnfa_search_csparse_nfa_q(
                 itBegin, 
                 itEnd, 
-                match_function_functor_check<RAIterator>(Match,begin, true),
+                match_function_functor_check<RAIterator>(Match, begin, end, true),
                 userdata,
                 local_state,
                 &local_state
@@ -500,7 +516,7 @@ AhoCorasickSearch::search(RAIterator begin, RAIterator end,
         ret = _bnfa_search_csparse_nfa_case(
             begin, 
             end, 
-            match_function_functor_check<RAIterator>(Match, begin,false),
+            match_function_functor_check<RAIterator>(Match, begin, end, false),
             userdata, 
             local_state,
             &local_state
@@ -513,7 +529,7 @@ AhoCorasickSearch::search(RAIterator begin, RAIterator end,
         ret = _bnfa_search_csparse_nfa_case(
             itBegin, 
             itEnd, 
-            match_function_functor_check<RAIterator>(Match, begin, false),
+            match_function_functor_check<RAIterator>(Match, begin, end, false),
             userdata, 
             local_state,
             &local_state
@@ -562,10 +578,16 @@ AhoCorasickSearch::_bnfa_search_csparse_nfa_q(RAIterator begin, RAIterator Tend,
                 int index;
                 bnfa_pattern_t* patrn = mlist->data;
                 int offset = (T - begin);
-                if ( offset < patrn->n)
+                int raw_index = offset - static_cast<int>(patrn->n) + 1;
+                if (raw_index < 0 && !patrn->nocase)
+                {
+                    mlist = mlist->next;
+                    continue;
+                }
+                if (raw_index < 0)
                     index = 0;
                 else
-                    index = offset - patrn->n + 1;
+                    index = raw_index;
                 nfound++;
                 if (_add_queue(mlist, index))
                 {
@@ -678,16 +700,18 @@ AhoCorasickSearch::_bnfa_search_csparse_nfa_case(RAIterator begin, RAIterator Te
                 int index;
                 patrn = mlist->data;
                 int offset = static_cast<int>(T - begin);
-                if (offset < patrn->n)
+                int raw_index = offset - static_cast<int>(patrn->n) + 1;
+                bool starts_before_buffer = raw_index < 0;
+                if (starts_before_buffer)
                     index = 0;
                 else
-                    index = offset - patrn->n + 1;
+                    index = raw_index;
                 nfound++;
                 /* Don't do anything specific for case sensitive patterns and not,
                 * since that will be covered by the rule tree itself.  Each tree
                 * might have both case sensitive & case insensitive patterns.
                 */
-                res = match_functor(patrn->userdata, index, userdata,patrn);
+                res = match_functor(patrn->userdata, index, userdata, patrn, starts_before_buffer);
                 if (res > 0)
                 {
                     *current_state = sindex;
@@ -758,7 +782,7 @@ AhoCorasickSearch::_process_queue(match_function_functor_check<RAIteratorUnderly
         {
             patrn = mlist->data;
             /*process a pattern -  case is handled by otn processing */
-            res = functor(patrn->userdata, it->pos, userdata,patrn);
+            res = functor(patrn->userdata, it->pos, userdata, patrn);
             if (res > 0)
             {    /* terminate matching */
                 match_queue.clear();

--- a/src/aho_corasick.h
+++ b/src/aho_corasick.h
@@ -461,10 +461,11 @@ AhoCorasickSearch::search(RAIterator begin, RAIterator end,
     any_t userdata, bnfa_state_index_t sindex, bnfa_state_index_t* current_state)
 {
     int ret = 0;
+    bnfa_state_index_t local_state = sindex;
 
     if (current_state)
     {
-        sindex = *current_state;
+        local_state = *current_state;
     }
 
     if (bnfaCaseMode == bnfa_case::BNFA_PER_PAT_CASE)
@@ -478,8 +479,8 @@ AhoCorasickSearch::search(RAIterator begin, RAIterator end,
                 itEnd, 
                 match_function_functor_check<RAIterator>(Match,begin,true),
                 userdata, 
-                sindex, 
-                current_state
+                local_state,
+                &local_state
                 );
         }
         else
@@ -489,8 +490,8 @@ AhoCorasickSearch::search(RAIterator begin, RAIterator end,
                 itEnd, 
                 match_function_functor_check<RAIterator>(Match,begin, true),
                 userdata,
-                sindex, 
-                current_state
+                local_state,
+                &local_state
                 );
         }
     }
@@ -501,8 +502,8 @@ AhoCorasickSearch::search(RAIterator begin, RAIterator end,
             end, 
             match_function_functor_check<RAIterator>(Match, begin,false),
             userdata, 
-            sindex, 
-            current_state
+            local_state,
+            &local_state
             );
     }
     else/* NOCASE */
@@ -514,9 +515,13 @@ AhoCorasickSearch::search(RAIterator begin, RAIterator end,
             itEnd, 
             match_function_functor_check<RAIterator>(Match, begin, false),
             userdata, 
-            sindex, 
-            current_state
+            local_state,
+            &local_state
             );
+    }
+    if (current_state)
+    {
+        *current_state = local_state;
     }
     return ret;
 }

--- a/tests/test_basic.cpp
+++ b/tests/test_basic.cpp
@@ -130,6 +130,31 @@ int main() {
     streaming_search.search(second_chunk.begin(), second_chunk.end(), count_match, &count, 0, &state);
     assert(count == 1);
 
+    AhoCorasickSearch split_per_pattern_case_search(AhoCorasickSearch::bnfa_case::BNFA_PER_PAT_CASE);
+    std::vector<char> split_pattern = {'a', 'a', 'a', 'a', 'a', 'a'};
+    assert(split_per_pattern_case_search.addPattern(split_pattern.begin(), split_pattern.end(), false, nullptr) == 0);
+    assert(split_per_pattern_case_search.compile() == 0);
+
+    std::vector<char> split_first_chunk = {'a', 'a', 'a'};
+    std::vector<char> split_second_chunk = {'a', 'a', 'a'};
+    count = 0;
+    state = 0;
+    split_per_pattern_case_search.search(
+        split_first_chunk.begin(), split_first_chunk.end(), count_match, &count, 0, &state);
+    split_per_pattern_case_search.search(
+        split_second_chunk.begin(), split_second_chunk.end(), count_match, &count, 0, &state);
+    assert(count == 0);
+
+    AhoCorasickSearch split_per_pattern_nocase_search(AhoCorasickSearch::bnfa_case::BNFA_PER_PAT_CASE);
+    add_pattern(split_per_pattern_nocase_search, "Needle", true);
+    assert(split_per_pattern_nocase_search.compile() == 0);
+
+    count = 0;
+    state = 0;
+    split_per_pattern_nocase_search.search(first_chunk.begin(), first_chunk.end(), count_match, &count, 0, &state);
+    split_per_pattern_nocase_search.search(second_chunk.begin(), second_chunk.end(), count_match, &count, 0, &state);
+    assert(count == 1);
+
     AhoCorasickSearch optimized_search;
     optimized_search.setOptimizeFailureStates(true);
     add_pattern(optimized_search, "he");

--- a/tests/test_basic.cpp
+++ b/tests/test_basic.cpp
@@ -65,6 +65,11 @@ int main() {
     assert(matches.size() == 1);
     assert(matches[0] == 9);
 
+    matches.clear();
+    ac.search(text.begin(), text.end(), collect_match, &matches, 0, nullptr);
+    assert(matches.size() == 1);
+    assert(matches[0] == 9);
+
     AhoCorasickSearch hello_search;
     const std::string hello = "hello";
     add_pattern(hello_search, hello);


### PR DESCRIPTION
## Summary

Fixes the review findings around search-state handling, split-buffer per-pattern case checks, and compile-time construction failures.

## Problem

- `search()` accepted `current_state == nullptr` in examples/docs, but internal search paths still wrote through that pointer.
- `BNFA_PER_PAT_CASE` exact-case verification could compare past the current buffer when a match spanned streamed chunks.
- Some automaton construction failures were not propagated, allowing `compile()` to report success after partial construction.

## Approach

- Use an internal local state for all search calls and copy it back only when the caller provides `current_state`.
- Bound exact-case verification to the current input buffer and avoid reporting case-sensitive per-pattern matches that begin before the current buffer, since the API carries automaton state but not prior bytes. Documented the streaming limitation in `README.md`.
- Propagate construction failures from `_bnfa_add_pattern_states()` and `_bnfa_build_nfa()`, preserve the original match-list pointer until resize succeeds, and make destruction tolerate partially initialized state.

## Validation

- `cmake --build build-review && ctest --test-dir build-review --output-on-failure`
- `cmake --build build-review-examples && ./build-review-examples/example`
- `cmake --build build-review-warnings && ctest --test-dir build-review-warnings --output-on-failure`
- `git diff --check master...HEAD`

The warning build still reports existing non-fatal warnings in legacy code.

## Testing notes

No deterministic allocator-failure regression test was added for compile failure propagation because the current code does not expose a non-intrusive allocation hook. The patch still propagates the existing internal failure returns and was validated under ASan through the available test binary.

## Risks and rollback

This preserves the documented nullable-state use case and avoids memory-unsafe split-buffer exact-case checks. The notable behavior choice is that `BNFA_PER_PAT_CASE` case-sensitive matches spanning buffers are not reported unless callers use a mode that does not require previous bytes for verification. Rollback is reverting this branch if downstream callers require the previous unsafe behavior, then replacing it with an API that carries enough trailing bytes for exact cross-buffer case verification.