### PR TITLE
Introduce RAII ownership for automaton storage

### DIFF
--- a/src/aho_corasick.cc
+++ b/src/aho_corasick.cc
@@ -172,11 +172,10 @@ AhoCorasickSearch::bnfa_state_index_t
 AhoCorasickSearch::_bnfa_list_get_next_state(bnfa_state_index_t state, unsigned char input) {
 
     if (state == 0) { /* Full (format) set of states  always */
-        bnfa_state_t * p = bnfaTransTable->states;
-        if (!p) {
+        if (bnfaTransTable->states.empty()) {
             return 0;
         }
-        return fullGetTransitionState(p[input]);
+        return fullGetTransitionState(bnfaTransTable->states[input]);
     } else {
         bnfa_trans_node_t* t = bnfaTransTable->transitions[state];
         while (t) {
@@ -207,22 +206,15 @@ AhoCorasickSearch::_bnfa_list_put_next_state(
     }
 
     if (state == 0) {
-        bnfa_state_t * p;
-
-        p = bnfaTransTable->states;
-        if (!p) {
-            p = bnfa_alloc(bnfaAlphabetSize, list_memory, (bnfa_state_t*)0); //NOLINT
-            if (!p) {
-                return -1;
-            }
-
-            bnfaTransTable->states = p;
+        if (bnfaTransTable->states.empty()) {
+            bnfaTransTable->states.assign(bnfaAlphabetSize, 0);
+            list_memory += bnfaTransTable->states.size() * sizeof(bnfa_state_t);
         }
-        if (p[input]!=0) {
-            p[input] = next_state;
+        if (bnfaTransTable->states[input]!=0) {
+            bnfaTransTable->states[input] = next_state;
             return 0;
         }
-        p[input] = next_state;
+        bnfaTransTable->states[input] = next_state;
     } else {
         bnfa_trans_node_t * p;
         bnfa_trans_node_t * tnew;
@@ -242,10 +234,7 @@ AhoCorasickSearch::_bnfa_list_put_next_state(
         }
 
         /* Definitely not an existing transition - add it */
-        tnew = bnfa_alloc(1, list_memory, (bnfa_trans_node_t*)0);//NOLINT
-        if (!tnew) {
-            return -1;
-        }
+        tnew = _make_transition_node();
 
         tnew->key = input;
         tnew->next_state = next_state;
@@ -263,30 +252,9 @@ AhoCorasickSearch::_bnfa_list_put_next_state(
 *   Free the entire transition list table
 */
 int AhoCorasickSearch::_bnfa_list_free_table() {
-    int i;
-    bnfa_trans_node_t * t, *p;
-
-    if (!bnfaTransTable) return 0;
-
-    if (bnfaTransTable->states) {
-        bnfa_free(bnfaTransTable->states, bnfaAlphabetSize, list_memory);
-    }
-
-    for (i = 1; i < bnfaMaxStates; i++) {
-        t = bnfaTransTable->transitions[i];
-
-        while (t) {
-            p = t;
-            t = t->next;
-            bnfa_free(p, list_memory);
-        }
-    }
-
-    if (bnfaTransTable) {
-        bnfa_free(bnfaTransTable->transitions, bnfaMaxStates, list_memory);
-        bnfa_free(bnfaTransTable, 1, list_memory);
-        bnfaTransTable = 0;
-    }
+    std::vector<std::unique_ptr<bnfa_trans_node_t>>().swap(transition_node_storage_);
+    bnfaTransTable.reset();
+    list_memory = 0;
 
     return 0;
 }
@@ -306,10 +274,10 @@ AhoCorasickSearch::_bnfa_list_conv_row_to_full(
     }
 
     if (state == 0) {
-        if (bnfaTransTable->states) {
+        if (!bnfaTransTable->states.empty()) {
             memcpy(
             full,
-            bnfaTransTable->states,
+            bnfaTransTable->states.data(),
             sizeof(bnfa_state_t)*bnfaAlphabetSize);
         } else {
             memset(full, 0, sizeof(bnfa_state_t)*bnfaAlphabetSize);
@@ -345,10 +313,10 @@ int
 AhoCorasickSearch::_bnfa_add_pattern_states(bnfa_pattern_t * p) {
     bnfa_state_index_t state, next;
     size_t  n;
-    unsigned char * pattern;
+    const unsigned char * pattern;
     bnfa_match_node_t  * pmn;
     n = p->n;
-    pattern = p->casepatrn;
+    pattern = p->casepatrn.data();
     state = 0;
 
     /*
@@ -397,11 +365,7 @@ AhoCorasickSearch::_bnfa_add_pattern_states(bnfa_pattern_t * p) {
     }
 
     /*  Add a pattern to the list of patterns terminated at this state */
-    pmn = bnfa_alloc(matchlist_memory, (bnfa_match_node_t*)0);
-    if (!pmn)
-    {
-        return -1;
-    }
+    pmn = _make_match_node();
 
     pmn->data = p;
     pmn->next = bnfaMatchList[state];
@@ -465,7 +429,7 @@ int AhoCorasickSearch::_bnfa_opt_nfa()
     int            cnt = 0;
     unsigned            k;
     bnfa_state_index_t fs, fr;
-    bnfa_state_index_t * FailState = bnfaFailState;
+    bnfa_state_index_t * FailState = bnfaFailState.data();
 
     for (k = 2; k < bnfaNumStates; k++)
     {
@@ -492,8 +456,8 @@ AhoCorasickSearch::_bnfa_build_nfa()
 {
     bnfa_state_index_t r,s;
     std::deque< bnfa_state_index_t > queue;
-    bnfa_state_index_t     * FailState = bnfaFailState;
-    bnfa_match_node_t ** MatchList = bnfaMatchList;
+    bnfa_state_index_t     * FailState = bnfaFailState.data();
+    bnfa_match_node_t ** MatchList = bnfaMatchList.data();
     bnfa_match_node_t  * mlist;
     bnfa_match_node_t  * px;
 
@@ -556,11 +520,7 @@ AhoCorasickSearch::_bnfa_build_nfa()
             for (mlist = MatchList[next]; mlist; mlist = mlist->next)
             {
                 /* Dup the node, don't copy the data */
-                px = bnfa_alloc(matchlist_memory, (bnfa_match_node_t*)0);
-                if (!px)
-                {
-                    return -1;
-                }
+                px = _make_match_node();
 
                 px->data = mlist->data;
 
@@ -601,7 +561,7 @@ AhoCorasickSearch::_bnfa_conv_list_to_csparse_array()
     unsigned            i;
     unsigned nc;
     bnfa_state_index_t      state;
-    bnfa_state_index_t    * FailState = bnfaFailState;
+    bnfa_state_index_t    * FailState = bnfaFailState.data();
     bnfa_state_t    * ps; /* transition list */
     bnfa_state_index_t    * pi; /* state indexes into ps */
     unsigned int      ps_index = 0;
@@ -658,27 +618,11 @@ AhoCorasickSearch::_bnfa_conv_list_to_csparse_array()
         return -1;
     }
 
-    /*
-    **  Alloc The Transition List -
-    **  we need an array of bnfa_state_t items of size 'nps'
-    */
-    ps = bnfa_alloc(nps, nextstate_memory, (bnfa_state_t*)0);
-    if (!ps)
-    {
-        /* Fatal */
-        return -1;
-    }
-    bnfaTransList = ps;
+    std::vector<bnfa_state_t> transition_list(nps);
+    ps = transition_list.data();
 
-    /*
-       State Index list for pi - we need an array of bnfa_state_index_t items of size 'NumStates'
-    */
-    pi = bnfa_alloc(bnfaNumStates, nextstate_memory, (bnfa_state_index_t*)0);
-    if (!pi)
-    {
-        /* Fatal */
-        return -1;
-    }
+    std::vector<bnfa_state_index_t> state_indexes(bnfaNumStates);
+    pi = state_indexes.data();
 
     /*
         Build the Transition List Array
@@ -826,7 +770,8 @@ AhoCorasickSearch::_bnfa_conv_list_to_csparse_array()
 
     }
 
-    bnfa_free(pi, bnfaNumStates, nextstate_memory);
+    bnfaTransList = std::move(transition_list);
+    nextstate_memory = bnfaTransList.size() * sizeof(bnfa_state_t);
 
     return 0;
 }
@@ -843,7 +788,7 @@ void AhoCorasickSearch::print()
     bnfa_state_t      * ps = 0;
 
 
-    MatchList = bnfaMatchList;
+    MatchList = bnfaMatchList.data();
 
     if (!bnfaNumStates)
         return;
@@ -852,7 +797,7 @@ void AhoCorasickSearch::print()
     {
         LogMessage("Print NFA-SPARSE state machine : %d active states\n",
             bnfaNumStates);
-        ps = bnfaTransList;
+        ps = bnfaTransList.data();
         if (!ps)
             return;
     }
@@ -928,7 +873,10 @@ void AhoCorasickSearch::print()
         {
             bnfa_pattern_t * pat;
             pat = (bnfa_pattern_t*)mlist->data;
-            LogMessage("---pattern : %.*s\n", pat->n, pat->casepatrn);
+            LogMessage(
+                "---pattern : %.*s\n",
+                static_cast<int>(pat->n),
+                reinterpret_cast<const char*>(pat->casepatrn.data()));
         }
     }
 }
@@ -945,11 +893,7 @@ AhoCorasickSearch::AhoCorasickSearch(bnfa_case flag)
     bnfaMaxStates = 0;
     bnfaNumTrans = 0;
     bnfaMatchStates = 0;
-    bnfaNextState = 0;
-    bnfaTransTable = 0;
-    bnfaMatchList = 0;
-    bnfaFailState = 0;
-    bnfaTransList = 0;
+    bnfaTransTable.reset();
 
     bnfaPatternCnt = 0;
     bnfaOptimizeFailureStates = false;
@@ -982,50 +926,47 @@ AhoCorasickSearch::setCase(bnfa_case flag)
     if (flag == bnfa_case::BNFA_NOCASE) bnfaCaseMode = flag;
 }
 
-/*
-*   Destructor
-*/
-AhoCorasickSearch::~AhoCorasickSearch()
+void
+AhoCorasickSearch::_reset_compiled_state()
 {
-    unsigned i;
-    bnfa_pattern_t * patrn, *ipatrn;
-    bnfa_match_node_t   * mlist, *ilist;
-
-    for (i = 0; bnfaMatchList && i < bnfaNumStates; i++)
-    {
-        /* free match list entries */
-        mlist = bnfaMatchList[i];
-
-        while (mlist)
-        {
-            ilist = mlist;
-            mlist = mlist->next;
-            bnfa_free(ilist, matchlist_memory);
-        }
-        bnfaMatchList[i] = 0;
-
-    }
-
     _bnfa_list_free_table();
+    std::vector<bnfa_match_node_t*>().swap(bnfaMatchList);
+    std::vector<std::unique_ptr<bnfa_match_node_t>>().swap(match_node_storage_);
+    std::vector<bnfa_state_index_t>().swap(bnfaFailState);
+    std::vector<bnfa_state_t>().swap(bnfaTransList);
+    match_queue.clear();
 
-    /* Free patterns */
-    patrn = bnfaPatterns;
-    while (patrn)
-    {
-        ipatrn = patrn;
-        patrn = patrn->next;
-        bnfa_free(ipatrn->casepatrn, ipatrn->n, pat_memory); //oops ??
-        bnfa_free(ipatrn, 1, pat_memory);
-    }
+    bnfaNumStates = 0;
+    bnfaMaxStates = 0;
+    bnfaNumTrans = 0;
+    bnfaMatchStates = 0;
 
-    /* Free arrays */
-    bnfa_free(bnfaFailState, bnfaNumStates, failstate_memory);
-    bnfa_free(bnfaMatchList, bnfaNumStates, matchlist_memory);
-    bnfa_free(bnfaNextState, bnfaNumStates, nextstate_memory);
-    bnfa_free(bnfaTransList, 
-        (2 * bnfaNumStates + bnfaNumTrans), 
-        nextstate_memory);
+    matchlist_memory = 0;
+    failstate_memory = 0;
+    nextstate_memory = 0;
 }
+
+AhoCorasickSearch::bnfa_trans_node_t*
+AhoCorasickSearch::_make_transition_node()
+{
+    auto node = std::make_unique<bnfa_trans_node_t>();
+    bnfa_trans_node_t* raw_node = node.get();
+    transition_node_storage_.push_back(std::move(node));
+    list_memory += sizeof(bnfa_trans_node_t);
+    return raw_node;
+}
+
+AhoCorasickSearch::bnfa_match_node_t*
+AhoCorasickSearch::_make_match_node()
+{
+    auto node = std::make_unique<bnfa_match_node_t>();
+    bnfa_match_node_t* raw_node = node.get();
+    match_node_storage_.push_back(std::move(node));
+    matchlist_memory += sizeof(bnfa_match_node_t);
+    return raw_node;
+}
+
+AhoCorasickSearch::~AhoCorasickSearch() = default;
 
 
 /*
@@ -1034,123 +975,106 @@ AhoCorasickSearch::~AhoCorasickSearch()
 int
 AhoCorasickSearch::compile()
 {
-    bnfa_pattern_t  * plist;
-    bnfa_match_node_t   ** tmpMatchList;
-    unsigned          cntMatchStates;
-    unsigned          i;
-
-    /* Count number of states */
-    for (plist = bnfaPatterns; plist != nullptr; plist = plist->next)
-    {
-        bnfaMaxStates += plist->n;
-    }
-    bnfaMaxStates++; /* one extra */
-
-    /* Alloc a List based State Transition table */
-    bnfaTransTable = bnfa_alloc(1, list_memory, (bnfa_trans_table_t*)0);
-    if (!bnfaTransTable)
-    {
+    auto fail = [this]() {
+        _reset_compiled_state();
         return -1;
-    }
-    bnfaTransTable->states = nullptr;
-    bnfaTransTable->transitions = bnfa_alloc(bnfaMaxStates, list_memory, (bnfa_trans_node_t**)0);
-    if (!bnfaTransTable->transitions)
-    {
-        bnfa_free(bnfaTransTable, 1, list_memory);
-        bnfaTransTable = nullptr;
-        return -1;
-    }
+    };
 
-    /*
-    ** Alloc a MatchList table -
-    ** this has a list of pattern matches for each state
-    */
-    bnfaMatchList = bnfa_alloc(
-        bnfaMaxStates,
-        matchlist_memory,
-        (bnfa_match_node_t**)0
-        );
-    if (!bnfaMatchList)
+    try
     {
-        return -1;
-    }
+        _reset_compiled_state();
 
-    /* Add each Pattern to the State Table - This forms a keyword trie using lists */
-    bnfaNumStates = 0;
-    for (plist = bnfaPatterns; plist != nullptr; plist = plist->next)
-    {
-        if (_bnfa_add_pattern_states(plist))
+        bnfa_pattern_t* plist;
+        unsigned cntMatchStates;
+        unsigned i;
+
+        /* Count number of states */
+        for (plist = bnfaPatterns; plist != nullptr; plist = plist->next)
         {
-            return -1;
+            bnfaMaxStates += plist->n;
         }
-    }
-    bnfaNumStates++; 
+        bnfaMaxStates++; /* one extra */
 
-    if (bnfaNumStates > BNFA_SPARSE_MAX_STATE)
-    {
-        return -1;  /* Call bnfaFree to clean up */
-    }
+        /* Alloc a List based State Transition table */
+        bnfaTransTable = std::make_unique<bnfa_trans_table_t>();
+        bnfaTransTable->transitions.assign(bnfaMaxStates, nullptr);
+        list_memory = sizeof(bnfa_trans_table_t) +
+            bnfaTransTable->transitions.size() * sizeof(bnfa_trans_node_t*);
 
-    /* ReAlloc a smaller MatchList table -  only need NumStates  */
-    tmpMatchList = bnfaMatchList;
+        /*
+        ** Alloc a MatchList table -
+        ** this has a list of pattern matches for each state
+        */
+        bnfaMatchList.assign(bnfaMaxStates, nullptr);
+        matchlist_memory = bnfaMatchList.size() * sizeof(bnfa_match_node_t*);
 
-    bnfa_match_node_t** resizedMatchList = bnfa_alloc(
-        bnfaNumStates,
-        matchlist_memory,
-        (bnfa_match_node_t**)0
-        );
-    if (!resizedMatchList)
-    {
-        return -1;
-    }
-
-    memcpy(resizedMatchList, tmpMatchList, sizeof(bnfa_match_node_t**) * bnfaNumStates);
-
-    bnfa_free(tmpMatchList, bnfaMaxStates, matchlist_memory);
-    bnfaMatchList = resizedMatchList;
-
-    /* Alloc a failure state table -  only need NumStates */
-    bnfaFailState = bnfa_alloc(bnfaNumStates, failstate_memory, (bnfa_state_index_t*)0);
-    if (!bnfaFailState)
-    {
-        return -1;
-    }
-
-    /* Build the nfa w/failure states - time the nfa construction */
-    if (_bnfa_build_nfa())
-    {
-        return -1;
-    }
-
-    /* Convert nfa storage format from list to full or sparse */
-    if (bnfaFormat == BNFA_SPARSE)
-    {
-        if (_bnfa_conv_list_to_csparse_array())
+        /* Add each Pattern to the State Table - This forms a keyword trie using lists */
+        bnfaNumStates = 0;
+        for (plist = bnfaPatterns; plist != nullptr; plist = plist->next)
         {
-            return -1;
+            if (_bnfa_add_pattern_states(plist))
+            {
+                return fail();
+            }
         }
-        bnfa_free(bnfaFailState, bnfaNumStates, failstate_memory);
-        bnfaFailState = 0;
+        bnfaNumStates++;
+
+        if (bnfaNumStates > BNFA_SPARSE_MAX_STATE)
+        {
+            return fail();
+        }
+
+        /* ReAlloc a smaller MatchList table -  only need NumStates  */
+        std::vector<bnfa_match_node_t*> resizedMatchList(bnfaNumStates);
+        std::copy_n(bnfaMatchList.begin(), bnfaNumStates, resizedMatchList.begin());
+        bnfaMatchList = std::move(resizedMatchList);
+        matchlist_memory = bnfaMatchList.size() * sizeof(bnfa_match_node_t*) +
+            match_node_storage_.size() * sizeof(bnfa_match_node_t);
+
+        /* Alloc a failure state table -  only need NumStates */
+        bnfaFailState.assign(bnfaNumStates, 0);
+        failstate_memory = bnfaFailState.size() * sizeof(bnfa_state_index_t);
+
+        /* Build the nfa w/failure states - time the nfa construction */
+        if (_bnfa_build_nfa())
+        {
+            return fail();
+        }
+
+        /* Convert nfa storage format from list to full or sparse */
+        if (bnfaFormat == BNFA_SPARSE)
+        {
+            if (_bnfa_conv_list_to_csparse_array())
+            {
+                return fail();
+            }
+            std::vector<bnfa_state_index_t>().swap(bnfaFailState);
+            failstate_memory = 0;
+        }
+        else
+        {
+            return fail();
+        }
+
+        /* Free up the Table Of Transition Lists */
+        _bnfa_list_free_table();
+
+        /* Count states with Pattern Matches */
+        cntMatchStates = 0;
+        for (i = 0; i < bnfaNumStates; i++)
+        {
+            if (bnfaMatchList[i])
+                cntMatchStates++;
+        }
+
+        bnfaMatchStates = cntMatchStates;
+
+        return 0;
     }
-    else
+    catch (const std::bad_alloc&)
     {
-        return -1;
+        return fail();
     }
-
-    /* Free up the Table Of Transition Lists */
-    _bnfa_list_free_table();
-
-    /* Count states with Pattern Matches */
-    cntMatchStates = 0;
-    for (i = 0; i < bnfaNumStates; i++)
-    {
-        if (bnfaMatchList[i])
-            cntMatchStates++;
-    }
-
-    bnfaMatchStates = cntMatchStates;
-
-    return 0;
 }
 
 /*

--- a/src/aho_corasick.cc
+++ b/src/aho_corasick.cc
@@ -1000,6 +1000,7 @@ AhoCorasickSearch::compile()
         bnfaTransTable->transitions.assign(bnfaMaxStates, nullptr);
         list_memory = sizeof(bnfa_trans_table_t) +
             bnfaTransTable->transitions.size() * sizeof(bnfa_trans_node_t*);
+        transition_node_storage_.reserve(bnfaMaxStates > 0 ? bnfaMaxStates - 1 : 0);
 
         /*
         ** Alloc a MatchList table -
@@ -1007,6 +1008,7 @@ AhoCorasickSearch::compile()
         */
         bnfaMatchList.assign(bnfaMaxStates, nullptr);
         matchlist_memory = bnfaMatchList.size() * sizeof(bnfa_match_node_t*);
+        match_node_storage_.reserve(bnfaPatternCnt);
 
         /* Add each Pattern to the State Table - This forms a keyword trie using lists */
         bnfaNumStates = 0;

--- a/src/aho_corasick.h
+++ b/src/aho_corasick.h
@@ -46,10 +46,13 @@
 #include <limits.h>
 #include <stdint.h>
 #include <cstddef>
+#include <memory>
 #include <set>
 #include <algorithm>
 #include <any>
 #include <iterator>
+#include <new>
+#include <vector>
 
 
 #include "uppercase_iterator.h"
@@ -193,34 +196,37 @@ private:
     *   Internal Pattern Representation
     */
 
-    typedef struct bnfa_pattern	{
-        struct bnfa_pattern * next;
+    struct bnfa_pattern {
+        bnfa_pattern* next = nullptr;
 
-        unsigned char       * casepatrn;   /* case specific */
-        unsigned              n;           /* pattern len */
-        bool                  nocase;      /* nocase flag */
-        any_t userdata;    /* ptr to users pattern data/info  */
+        std::vector<unsigned char> casepatrn; /* case specific */
+        unsigned                   n = 0;     /* pattern len */
+        bool                       nocase = false; /* nocase flag */
+        any_t                      userdata;  /* ptr to users pattern data/info  */
 
-    } bnfa_pattern_t;
+    };
+    using bnfa_pattern_t = bnfa_pattern;
 
     /*
     *  List format transition node
     */
-    typedef struct bnfa_trans_node_s {
-        unsigned int               key; // 8 bit character
-        bnfa_state_index_t         next_state;
-        struct bnfa_trans_node_s * next;
+    struct bnfa_trans_node_s {
+        unsigned int       key = 0; // 8 bit character
+        bnfa_state_index_t next_state = 0;
+        bnfa_trans_node_s* next = nullptr;
 
-    } bnfa_trans_node_t;
+    };
+    using bnfa_trans_node_t = bnfa_trans_node_s;
 
     /*
     *  List format patterns
     */
-    typedef struct bnfa_match_node_s {
-        bnfa_pattern_t* data;
-        struct bnfa_match_node_s * next;
+    struct bnfa_match_node_s {
+        bnfa_pattern_t* data = nullptr;
+        bnfa_match_node_s* next = nullptr;
 
-    } bnfa_match_node_t;
+    };
+    using bnfa_match_node_t = bnfa_match_node_s;
 
     /*
     *  Final storage type for the state transitions
@@ -275,8 +281,8 @@ private:
                     return 0;
 
                 if (std::equal(
-                        pattern->casepatrn,
-                        pattern->casepatrn+pattern->n,
+                        pattern->casepatrn.data(),
+                        pattern->casepatrn.data() + pattern->n,
                         pattern_begin
                         )
                     )
@@ -309,19 +315,23 @@ private:
     unsigned           bnfaNumTrans;
     unsigned           bnfaMatchStates;
 
-    typedef struct bnfa_trans_table {
-        bnfa_state_t* states;                // zero state transitions
-        bnfa_trans_node_t** transitions;     // per state transition lists
-    } bnfa_trans_table_t;
+    struct bnfa_trans_table {
+        std::vector<bnfa_state_t> states;             // zero state transitions
+        std::vector<bnfa_trans_node_t*> transitions;  // per state transition lists
+    };
+    using bnfa_trans_table_t = bnfa_trans_table;
 
-    bnfa_trans_table_t* bnfaTransTable;
+    std::unique_ptr<bnfa_trans_table_t> bnfaTransTable;
 
-    bnfa_state_t       ** bnfaNextState;
-    bnfa_match_node_t  ** bnfaMatchList;
-    bnfa_state_index_t       * bnfaFailState;
+    std::vector<bnfa_match_node_t*> bnfaMatchList;
+    std::vector<bnfa_state_index_t> bnfaFailState;
 
-    bnfa_state_t       * bnfaTransList;
+    std::vector<bnfa_state_t> bnfaTransList;
     int                bnfaForceFullZeroState;
+
+    std::vector<std::unique_ptr<bnfa_pattern_t>> pattern_storage_;
+    std::vector<std::unique_ptr<bnfa_trans_node_t>> transition_node_storage_;
+    std::vector<std::unique_ptr<bnfa_match_node_t>> match_node_storage_;
 
     size_t 			   bnfa_memory;
     size_t 			   pat_memory;
@@ -359,6 +369,9 @@ private:
     int _bnfa_opt_nfa();
     int _bnfa_build_nfa();
     int _bnfa_conv_list_to_csparse_array();
+    void _reset_compiled_state();
+    bnfa_trans_node_t* _make_transition_node();
+    bnfa_match_node_t* _make_match_node();
     
     template <typename RAIteratorUnderlying,typename RAIterator>
     unsigned _bnfa_search_csparse_nfa_q(RAIterator begin, RAIterator end,
@@ -458,16 +471,6 @@ private:
         }
         return -1;
     }
-    template <typename T>
-    static T* bnfa_alloc(size_t n, size_t& m, T*);
-    template <typename T>
-    static T* bnfa_alloc(size_t& m, T*);
-    template <typename T>
-    static void bnfa_free(T* p, size_t n, size_t& m);
-    template <typename T>
-    static void bnfa_free(T* p, size_t& m);
-
-
 };
 
 template<typename RAIterator>
@@ -551,8 +554,8 @@ AhoCorasickSearch::_bnfa_search_csparse_nfa_q(RAIterator begin, RAIterator Tend,
     bnfa_match_node_t  * mlist;
     RAIterator T = begin;
 
-    bnfa_match_node_t ** MatchList = bnfaMatchList;
-    bnfa_state_t       * transList = bnfaTransList;
+    bnfa_match_node_t ** MatchList = bnfaMatchList.data();
+    bnfa_state_t       * transList = bnfaTransList.data();
     bnfa_state_index_t   last_sindex;
     unsigned int nfound = 0;
 
@@ -608,61 +611,6 @@ AhoCorasickSearch::_bnfa_search_csparse_nfa_q(RAIterator begin, RAIterator Tend,
 
 
 /*
-* Custom memory allocator
-*/
-template <typename T>
-/*static*/ 
-T* AhoCorasickSearch::bnfa_alloc(size_t n, size_t& m, T*)
-{
-    T* p;
-    if (n > 1)
-        p = new (std::nothrow) T[n]();
-    else
-        p = new (std::nothrow) T();
-    if (p)
-    {
-        m += n *sizeof(T);
-    }
-    return p;
-}
-
-template <typename T>
-/*static*/ 
-T* AhoCorasickSearch::bnfa_alloc(size_t& m, T*)
-{
-    T* p = new (std::nothrow) T();
-    if (p)
-    {
-        m += sizeof(T);
-    }
-    return p;
-}
-
-template <typename T>
-/*static*/ 
-void AhoCorasickSearch::bnfa_free(T* p, size_t n, size_t& m)
-{
-    if (p)
-    {
-        if (n > 1)
-            delete[] p;
-        else
-            delete p;
-        m -= n * sizeof(T);
-    }
-}
-template <typename T>
-/*static*/
-void AhoCorasickSearch::bnfa_free(T* p, size_t& m)
-{
-    if (p)
-    {
-        delete p;
-        m -= sizeof(T);
-    }
-}
-
-/*
 * Case specific search, global to all patterns
 */
 template<typename RAIteratorUnderlying, typename RAIterator>
@@ -673,9 +621,9 @@ AhoCorasickSearch::_bnfa_search_csparse_nfa_case(RAIterator begin, RAIterator Te
 {
     bnfa_match_node_t  * mlist;
     RAIterator T = begin;
-    bnfa_match_node_t ** MatchList = bnfaMatchList;
+    bnfa_match_node_t ** MatchList = bnfaMatchList.data();
     bnfa_pattern_t     * patrn;
-    bnfa_state_t       * transList = bnfaTransList;
+    bnfa_state_t       * transList = bnfaTransList.data();
     unsigned             nfound = 0;
     bnfa_state_index_t             last_match = LAST_STATE_INIT;
     bnfa_state_index_t             last_match_saved = LAST_STATE_INIT;
@@ -738,31 +686,31 @@ AhoCorasickSearch::addPattern(
     RAIterator patBegin, RAIterator patEnd, bool nocase,
     any_t userdata)
 {
-    bnfa_pattern_t * plist;
     if (patEnd <= patBegin || (patEnd - patBegin > UINT_MAX) )
         return -1;
     unsigned n = patEnd - patBegin;
 
-    plist = bnfa_alloc(1, pat_memory, (bnfa_pattern_t*)0); //NOLINT
-    if (!plist) return -1;
-
-    plist->casepatrn = bnfa_alloc(n, pat_memory, (unsigned char *)0); //NOLINT
-    if (!plist->casepatrn)
+    try
     {
-        bnfa_free(plist, pat_memory);
+        auto owned_pattern = std::make_unique<bnfa_pattern_t>();
+        bnfa_pattern_t* plist = owned_pattern.get();
+        plist->casepatrn.assign(patBegin, patEnd);
+        plist->n = n;
+        plist->nocase = nocase;
+        plist->userdata = userdata;
+
+        pattern_storage_.push_back(std::move(owned_pattern));
+
+        plist->next = bnfaPatterns; /* insert at front of list */
+        bnfaPatterns = plist;
+
+        pat_memory += sizeof(bnfa_pattern_t) + plist->casepatrn.size() * sizeof(unsigned char);
+        bnfaPatternCnt++;
+    }
+    catch (const std::bad_alloc&)
+    {
         return -1;
     }
-
-    std::copy(patBegin, patEnd, plist->casepatrn);
-
-    plist->n = n;
-    plist->nocase = nocase;
-    plist->userdata = userdata;
-
-    plist->next = bnfaPatterns; /* insert at front of list */
-    bnfaPatterns = plist;
-
-    bnfaPatternCnt++;
 
     return 0;
 }

--- a/tests/test_basic.cpp
+++ b/tests/test_basic.cpp
@@ -199,5 +199,26 @@ int main() {
     assert(has_match(identified_matches, {2, 1}));
     assert(has_match(identified_matches, {3, 2}));
 
+    AhoCorasickSearch recompiled_search;
+    add_pattern(recompiled_search, "one", false, 1);
+    assert(recompiled_search.compile() == 0);
+    assert(recompiled_search.compile() == 0);
+    add_pattern(recompiled_search, "two", false, 2);
+    assert(recompiled_search.compile() == 0);
+
+    const std::string recompiled_text = "one two";
+    identified_matches.clear();
+    state = 0;
+    recompiled_search.search(
+        recompiled_text.begin(),
+        recompiled_text.end(),
+        collect_identified_match,
+        &identified_matches,
+        0,
+        &state);
+    assert(identified_matches.size() == 2);
+    assert(has_match(identified_matches, {1, 0}));
+    assert(has_match(identified_matches, {2, 4}));
+
     return 0;
 }


### PR DESCRIPTION
## Problem

The automaton implementation still used custom allocation/free helpers and destructor-driven manual cleanup for patterns, transition tables, match lists, failure-state tables, and compact transition storage. That made ownership harder to reason about, especially on compile error paths and repeated compilation of the same object.

## Approach

- Replace owned raw arrays with `std::vector` storage.
- Replace owned linked-list nodes with `std::unique_ptr` ownership while keeping raw pointers as non-owning traversal links.
- Move compiled-state cleanup into an explicit reset path used before rebuilds and on compile failure.
- Add focused regression coverage for recompiling the same search object after compiled storage exists.
- Reserve predictable compile-time node-owner storage to avoid unnecessary owner-vector reallocations.

## Risks and tradeoffs

The public API and compact sparse search representation are unchanged. The linked-list traversal pointers remain raw by design, but their lifetime is now anchored by RAII-owned storage. Internal memory reporting still reflects the managed automaton payloads rather than every allocator bookkeeping detail of standard containers.

## Validation

- `cmake -S . -B build -DBUILD_TESTS=ON -DENABLE_ASAN=ON`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`