### PR TITLE
[codex] Document public API and contribution workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@
 # Temporary build directories
 build*/
 /build*/
+
+# Generated documentation
+/docs/api/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ project(AhoCorasickSearch LANGUAGES CXX)
 
 option(BUILD_EXAMPLES "Build example binaries" OFF)
 option(BUILD_TESTS "Build tests" OFF)
+option(BUILD_DOCS "Enable the Doxygen documentation target" ON)
 option(ENABLE_ASAN "Build with AddressSanitizer" OFF)
 option(ENABLE_COVERAGE "Build tests with code coverage instrumentation" OFF)
 
@@ -61,6 +62,26 @@ if(BUILD_EXAMPLES)
     target_link_libraries(example aho_corasick_search)
     enable_asan_for(example)
     enable_coverage_for(example)
+endif()
+
+if(BUILD_DOCS)
+    find_program(DOXYGEN_EXECUTABLE doxygen)
+    if(DOXYGEN_EXECUTABLE)
+        add_custom_target(docs
+            COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_SOURCE_DIR}/docs/api
+            COMMAND ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+            COMMENT "Generating API documentation with Doxygen"
+            VERBATIM
+        )
+    else()
+        add_custom_target(docs
+            COMMAND ${CMAKE_COMMAND} -E echo "Doxygen executable not found. Install Doxygen or configure with -DBUILD_DOCS=OFF."
+            COMMAND ${CMAKE_COMMAND} -E false
+            COMMENT "Doxygen is required to generate API documentation"
+            VERBATIM
+        )
+    endif()
 endif()
 
 if(BUILD_TESTS)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,78 @@
+# Contributing
+
+Thanks for helping improve Aho-Corasick Search. This project is small, so
+changes should stay focused, easy to review, and compatible with the existing
+GPLv2 license.
+
+## License
+
+All contributions must remain under GNU General Public License version 2
+(GPLv2). Do not add files with conflicting license terms. If a contribution is
+derived from another project, include the required attribution and confirm that
+the source license is compatible with GPLv2.
+
+## Development Workflow
+
+1. Make one logical change at a time.
+2. Preserve the existing public API unless the change explicitly requires an
+   incompatible update.
+3. Update tests for behavioral changes.
+4. Update `README.md` and Doxygen comments when public behavior or API usage
+   changes.
+5. Keep generated files out of commits, including `build*/` directories and
+   `docs/api/`.
+
+## Build And Test
+
+Use CMake for normal development:
+
+```sh
+cmake -S . -B build -DBUILD_TESTS=ON -DBUILD_EXAMPLES=ON -DENABLE_ASAN=ON
+cmake --build build
+ctest --test-dir build --output-on-failure
+```
+
+Coverage reports can be generated with GCC or Clang:
+
+```sh
+cmake -S . -B build-coverage -DBUILD_TESTS=ON -DENABLE_COVERAGE=ON
+cmake --build build-coverage --target coverage
+```
+
+Generated coverage files are written under `build-coverage/coverage/`.
+
+## API Documentation
+
+Install Doxygen, configure the project, then build the `docs` target:
+
+```sh
+cmake -S . -B build -DBUILD_DOCS=ON
+cmake --build build --target docs
+```
+
+The generated HTML documentation is written to `docs/api/html/`.
+
+## C++ Guidelines
+
+- The project currently targets C++17.
+- Prefer standard library containers and RAII for new code.
+- Keep ownership and lifetime rules explicit.
+- Avoid raw `new` and `delete` in new code.
+- Keep comments concise and focused on non-obvious behavior.
+- Validate input at API boundaries and keep failure modes explicit.
+
+## Test Expectations
+
+Add or update tests for:
+
+- Pattern insertion and compilation behavior.
+- Case-sensitive, case-insensitive, and per-pattern matching.
+- Failure-state transitions and overlapping matches.
+- Streaming searches split across buffers.
+- Error paths such as empty patterns and invalid options.
+
+## Security And Dependencies
+
+Treat search input and CLI arguments as untrusted. Avoid unsafe parsing,
+unchecked buffer operations, and unnecessary dependencies. New dependencies
+should be mature, maintained, and justified by a clear benefit.

--- a/Doxyfile
+++ b/Doxyfile
@@ -1,0 +1,42 @@
+# Doxygen configuration for Aho-Corasick Search.
+
+PROJECT_NAME           = "Aho-Corasick Search"
+PROJECT_BRIEF          = "Sparse NFA based Aho-Corasick multi-pattern search library"
+OUTPUT_DIRECTORY       = docs/api
+
+INPUT                  = README.md \
+                         CONTRIBUTING.md \
+                         src/aho_corasick.h
+USE_MDFILE_AS_MAINPAGE = README.md
+FILE_PATTERNS          = *.h \
+                         *.md
+RECURSIVE              = NO
+
+EXTRACT_ALL            = NO
+EXTRACT_PRIVATE        = NO
+EXTRACT_STATIC         = NO
+HIDE_UNDOC_MEMBERS     = NO
+HIDE_UNDOC_CLASSES     = NO
+
+MARKDOWN_SUPPORT       = YES
+JAVADOC_AUTOBRIEF      = YES
+FULL_PATH_NAMES        = NO
+STRIP_FROM_PATH        = .
+SORT_MEMBER_DOCS       = NO
+
+ENABLE_PREPROCESSING   = YES
+MACRO_EXPANSION        = YES
+PREDEFINED             = BNFA_STATE_64BITS
+
+GENERATE_HTML          = YES
+GENERATE_LATEX         = NO
+GENERATE_XML           = NO
+GENERATE_TREEVIEW      = YES
+HTML_OUTPUT            = html
+
+QUIET                  = NO
+WARNINGS               = YES
+WARN_IF_UNDOCUMENTED   = YES
+WARN_AS_ERROR          = NO
+
+HAVE_DOT               = NO

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The code is released under the terms of the **GNU General Public License version
 All sources are located under the `src/` directory. To build your own program that links against the library you need a C++17-capable compiler. The example below compiles `examples/example.cpp` together with the library sources:
 
 ```sh
-g++ -std=c++17 -O2 examples/example.cpp src/aho_corasick.cc -o example
+g++ -std=c++17 -O2 -Isrc examples/example.cpp src/aho_corasick.cc -o example
 ```
 
 The project also includes a cross‑platform [CMake](https://cmake.org/) build
@@ -33,10 +33,47 @@ cmake --build . --target coverage
 
 The generated `gcov` reports are written to `build-coverage/coverage/`.
 
+To generate API documentation, install Doxygen and build the `docs` target:
+
+```sh
+cmake -S . -B build -DBUILD_DOCS=ON
+cmake --build build --target docs
+```
+
+The generated HTML documentation is written to `docs/api/html/`.
+
+## Public API
+
+Include `aho_corasick.h` and use the `textsearch::AhoCorasickSearch` class.
+
+Typical lifecycle:
+
+1. Construct `AhoCorasickSearch`, optionally selecting a case mode.
+2. Add all patterns with `addPattern()`.
+3. Call `compile()`.
+4. Call `search()` with a callback that receives each match.
+
+Case modes:
+
+- `BNFA_CASE`: case-sensitive matching.
+- `BNFA_NOCASE`: case-insensitive matching for all patterns.
+- `BNFA_PER_PAT_CASE`: each pattern decides case handling through the
+  `nocase` argument passed to `addPattern()`.
+
+The match callback receives the pattern userdata, the zero-based match start
+index in the current search buffer, and the search userdata. Return a positive
+value from the callback to stop searching early; return `0` to keep scanning.
+Use callback side effects as the authoritative match-reporting mechanism.
+
+`search()` accepts random-access iterators over `char` or `unsigned char`
+compatible data. For single-buffer searches, pass `nullptr` for
+`current_state`. For streaming searches, keep a `bnfa_state_index_t` initialized
+to `0` and pass its address to each call.
+
 ## Usage example
 
 ```cpp
-#include "src/aho_corasick.h"
+#include "aho_corasick.h"
 #include <iostream>
 #include <string>
 
@@ -80,3 +117,8 @@ program. Run `Ctrl+Shift+B` to compile it or start the **Debug Example**
 configuration to launch it under the debugger. A similar **Debug test_basic**
 configuration and `build test_basic` task are provided for debugging the unit
 test.
+
+## Contributing
+
+See `CONTRIBUTING.md` for build, test, documentation, style, and licensing
+guidelines.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,4 @@
+# Documentation
+
+Generated Doxygen API documentation is written to `docs/api/html/` by the
+CMake `docs` target.

--- a/src/aho_corasick.h
+++ b/src/aho_corasick.h
@@ -76,43 +76,81 @@
 namespace textsearch {
 
 
-/*
-*   Aho-Corasick State Machine Struct
-*/
+/**
+ * @brief Sparse NFA based Aho-Corasick multi-pattern search engine.
+ *
+ * Add all patterns, compile the automaton, then search one or more buffers.
+ * The class is not copyable. It owns the compiled automaton and releases all
+ * allocated storage in the destructor.
+ */
 class AhoCorasickSearch {
 public:
+    /// Type-erased data passed through pattern registration and search callbacks.
     using any_t = std::any;
+
+    /**
+     * @brief Match callback signature.
+     *
+     * @param pattern_userdata Userdata supplied when the matching pattern was added.
+     * @param index Zero-based start offset of the match in the current search buffer.
+     * @param search_userdata Userdata supplied to search().
+     * @return Return a positive value to stop searching early; return 0 to continue.
+     */
     typedef int(*match_function_ptr_t)(any_t pattern_userdata, int index, any_t search_userdata);
 #ifdef BNFA_STATE_64BITS
+    /// Packed automaton storage word.
     typedef uint64_t bnfa_state_t;
+    /// Index into the packed automaton state storage.
     typedef uint_least64_t  bnfa_state_index_t;
 #else
+    /// Packed automaton storage word.
     typedef uint32_t bnfa_state_t;
+    /// Index into the packed automaton state storage.
     typedef uint_least32_t bnfa_state_index_t;
 #endif
+    /// Controls how pattern and input case are handled.
     enum class bnfa_case : int {
-        BNFA_PER_PAT_CASE, // DEFAULT:case-sensitivity is specified per pattern
-        BNFA_CASE,         // binary search (case sensitive), fastest mode
-        BNFA_NOCASE        // case-insensitive search
+        BNFA_PER_PAT_CASE, ///< Case sensitivity is specified per pattern.
+        BNFA_CASE,         ///< Case-sensitive binary matching.
+        BNFA_NOCASE        ///< Case-insensitive matching for all patterns.
     };
 
+    /**
+     * @brief Set the case handling mode.
+     *
+     * Set this before adding patterns and compiling the automaton. Changing the
+     * case mode after compile() is not supported.
+     */
     void setCase(bnfa_case flag);
 
-
+    /// Create an empty search engine using the requested case mode.
     explicit AhoCorasickSearch(bnfa_case flag = bnfa_case::BNFA_CASE);
+
+    /// Release all pattern and automaton storage.
     ~AhoCorasickSearch();
     
+    /**
+     * @brief Enable or disable failure-state optimization during compile().
+     *
+     * This must be configured before compile().
+     */
     void setOptimizeFailureStates(bool flag=true);
 
-    //
-    // Add a pattern to search
-    //   patBegin,patEnd: are char/unsigned char iterators
-    //                    specifying the pattern.
-    //   nocase: if true, case insensitive search
-    //           otherwise binary search
-    //           Behavior is dependent on the case mode
-    //           if BNFA_NOCASE or BNFA_CASE, this setting is ignored
-    //   userdata: a pointer to user-specific data associated to pattern
+    /**
+     * @brief Add a pattern to the automaton input set.
+     *
+     * Patterns must be added before compile(). Empty patterns and patterns
+     * larger than UINT_MAX bytes are rejected.
+     *
+     * @tparam RAIterator Random-access iterator over char-compatible bytes.
+     * @param patBegin First pattern byte.
+     * @param patEnd One-past-the-end pattern byte.
+     * @param nocase In BNFA_PER_PAT_CASE mode, true makes this pattern
+     * case-insensitive. In BNFA_CASE and BNFA_NOCASE modes this value is
+     * ignored.
+     * @param userdata User data passed back to the match callback.
+     * @return 0 on success, -1 on invalid input or allocation failure.
+     */
     template<typename RAIterator>
     int addPattern(
         RAIterator patBegin,
@@ -121,12 +159,35 @@ public:
         any_t userdata
         );
 
+    /**
+     * @brief Build the searchable automaton from the added patterns.
+     *
+     * @return 0 on success, -1 on allocation failure or unsupported automaton
+     * size/format.
+     */
     int compile();
 
-    // current_state is optional for single-buffer searches. Pass the same
-    // non-null state pointer across calls to continue matching across buffers.
-    // In BNFA_PER_PAT_CASE, case-sensitive patterns that begin before the
-    // current buffer cannot be exact-case verified and are not reported.
+    /**
+     * @brief Search a buffer and report matches through a callback.
+     *
+     * current_state is optional for single-buffer searches. Pass the same
+     * non-null state pointer across calls to continue matching across buffers.
+     * In BNFA_PER_PAT_CASE, case-sensitive patterns that begin before the
+     * current buffer cannot be exact-case verified and are not reported.
+     *
+     * @tparam RAIterator Random-access iterator over char-compatible bytes.
+     * @param begin First input byte.
+     * @param end One-past-the-end input byte.
+     * @param match Callback invoked for each reported match.
+     * @param userdata User data passed to the callback as search_userdata.
+     * @param sindex Initial automaton state for legacy callers. Use 0 for new
+     * searches.
+     * @param current_state Optional state pointer for streaming searches. If
+     * non-null, its input value overrides sindex and its output value can be
+     * passed to the next search() call.
+     * @return Legacy status/count value. Use the callback as the authoritative
+     * match-reporting mechanism.
+     */
     template<typename RAIterator>
     unsigned search(RAIterator begin, RAIterator end,
         match_function_ptr_t match,
@@ -134,10 +195,14 @@ public:
         bnfa_state_index_t sindex,
         bnfa_state_index_t* current_state);
 
+    /// Return the number of patterns added to this search engine.
     int getPatternCount();
 
-    void print(); /* prints the nfa states-verbose!! */
-    void printInfo(); /* print info on this search engine */
+    /// Print the compiled NFA states to stderr. Intended for diagnostics.
+    void print();
+    /// Print memory and state statistics to stderr.
+    void printInfo();
+    /// Print memory and state statistics to stderr with a legacy text argument.
     void printInfoEx(char * text);
 private:
 


### PR DESCRIPTION
## Problem

The repository had build and usage notes, but it did not have contributor guidance, generated API documentation support, or a concise public API reference for `AhoCorasickSearch`.

## Approach

- Added `CONTRIBUTING.md` with GPLv2, workflow, build/test, documentation, C++ style, test, and dependency guidance.
- Added a Doxygen configuration and CMake `docs` target that generates HTML under `docs/api/html/`.
- Expanded `README.md` with Doxygen generation instructions and a clearer public API overview.
- Added Doxygen comments to the public `AhoCorasickSearch` API.
- Ignored generated documentation output while keeping a tracked `docs/README.md` note.

## Impact

This is documentation and build-target plumbing only. It does not change search behavior or public API signatures.

## Risks And Tradeoffs

- The `docs` target requires Doxygen. If Doxygen is missing, the target fails with an explicit install/configuration message.
- Generated HTML is intentionally not committed; contributors should regenerate it locally when needed.

## Validation

- `cmake -S . -B build-docs-check -DBUILD_TESTS=ON -DBUILD_DOCS=ON`
- `cmake --build build-docs-check --target docs`
- `cmake --build build-docs-check && ctest --test-dir build-docs-check --output-on-failure`
- `g++ -std=c++17 -O2 -Isrc examples/example.cpp src/aho_corasick.cc -o /tmp/aho-readme-example-docs && /tmp/aho-readme-example-docs`
- `git diff --check`