### PR TITLE
Add Python benchmark integration and transition tuning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ project(AhoCorasickSearch LANGUAGES CXX)
 
 option(BUILD_EXAMPLES "Build example binaries" OFF)
 option(BUILD_TESTS "Build tests" OFF)
+option(BUILD_PYTHON_EXTENSION "Build the native CPython extension" OFF)
 option(ENABLE_ASAN "Build with AddressSanitizer" OFF)
 option(ENABLE_COVERAGE "Build tests with code coverage instrumentation" OFF)
 
@@ -63,6 +64,40 @@ if(BUILD_EXAMPLES)
     enable_coverage_for(example)
 endif()
 
+if(BUILD_PYTHON_EXTENSION)
+    if(CMAKE_VERSION VERSION_LESS 3.15)
+        message(FATAL_ERROR "BUILD_PYTHON_EXTENSION requires CMake 3.15 or newer")
+    endif()
+
+    find_package(Python 3.10 COMPONENTS Interpreter Development.Module REQUIRED)
+
+    execute_process(
+        COMMAND ${Python_EXECUTABLE} -m nanobind --cmake_dir
+        OUTPUT_VARIABLE NANOBIND_CMAKE_DIR
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_QUIET
+        RESULT_VARIABLE NANOBIND_CMAKE_DIR_RESULT
+    )
+    if(NOT NANOBIND_CMAKE_DIR_RESULT EQUAL 0)
+        message(FATAL_ERROR "BUILD_PYTHON_EXTENSION requires nanobind. Install it with: ${Python_EXECUTABLE} -m pip install nanobind")
+    endif()
+
+    list(APPEND CMAKE_PREFIX_PATH "${NANOBIND_CMAKE_DIR}")
+    find_package(nanobind CONFIG REQUIRED)
+
+    nanobind_add_module(aho_corasick_search_ext
+        NOMINSIZE
+        python/aho_corasick_search_ext.cpp
+    )
+    target_link_libraries(aho_corasick_search_ext PRIVATE aho_corasick_search)
+    target_compile_features(aho_corasick_search_ext PRIVATE cxx_std_17)
+    set_target_properties(aho_corasick_search_ext PROPERTIES
+        CXX_STANDARD 17
+        CXX_STANDARD_REQUIRED YES
+        CXX_EXTENSIONS NO
+    )
+endif()
+
 if(BUILD_TESTS)
     enable_testing()
     add_executable(test_basic tests/test_basic.cpp)
@@ -93,6 +128,16 @@ if(BUILD_TESTS)
             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
             DEPENDS test_basic
             COMMENT "Running unit tests and generating gcov coverage reports"
+        )
+    endif()
+
+    if(BUILD_PYTHON_EXTENSION)
+        add_test(
+            NAME python_extension
+            COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_python_extension.py
+        )
+        set_tests_properties(python_extension PROPERTIES
+            ENVIRONMENT "PYTHONPATH=$<TARGET_FILE_DIR:aho_corasick_search_ext>"
         )
     endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ option(BUILD_TESTS "Build tests" OFF)
 option(BUILD_PYTHON_EXTENSION "Build the native CPython extension" OFF)
 option(ENABLE_ASAN "Build with AddressSanitizer" OFF)
 option(ENABLE_COVERAGE "Build tests with code coverage instrumentation" OFF)
+option(ENABLE_SEARCH_STATS "Enable native search instrumentation counters" OFF)
 
 set(ASAN_FLAGS -fsanitize=address -fno-omit-frame-pointer -g)
 set(COVERAGE_COMPILE_FLAGS --coverage -O0 -g)
@@ -49,6 +50,10 @@ target_include_directories(aho_corasick_search
     PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
 )
+
+if(ENABLE_SEARCH_STATS)
+    target_compile_definitions(aho_corasick_search PUBLIC AHO_CORASICK_SEARCH_STATS)
+endif()
 
 # Require C++17
 set_target_properties(aho_corasick_search PROPERTIES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,21 @@ option(BUILD_PYTHON_EXTENSION "Build the native CPython extension" OFF)
 option(ENABLE_ASAN "Build with AddressSanitizer" OFF)
 option(ENABLE_COVERAGE "Build tests with code coverage instrumentation" OFF)
 option(ENABLE_SEARCH_STATS "Enable native search instrumentation counters" OFF)
+option(ENABLE_FAILURELESS_FULL_ROWS "Resolve full-row failure transitions at compile time" ON)
+set(FULL_ROW_MIN_TRANSITIONS 4 CACHE STRING "Minimum transition count that stores a non-root row in full format")
+set(FAILURELESS_CACHE_MAX_STATES 0 CACHE STRING "Maximum states with precomputed failureless transitions; 0 disables the cache")
+
+if("${FULL_ROW_MIN_TRANSITIONS}" MATCHES "^[0-9][0-9]*$")
+else()
+    message(FATAL_ERROR "FULL_ROW_MIN_TRANSITIONS must be an integer from 1 to 64")
+endif()
+if(FULL_ROW_MIN_TRANSITIONS LESS 1 OR FULL_ROW_MIN_TRANSITIONS GREATER 64)
+    message(FATAL_ERROR "FULL_ROW_MIN_TRANSITIONS must be an integer from 1 to 64")
+endif()
+if("${FAILURELESS_CACHE_MAX_STATES}" MATCHES "^[0-9][0-9]*$")
+else()
+    message(FATAL_ERROR "FAILURELESS_CACHE_MAX_STATES must be a non-negative integer")
+endif()
 
 set(ASAN_FLAGS -fsanitize=address -fno-omit-frame-pointer -g)
 set(COVERAGE_COMPILE_FLAGS --coverage -O0 -g)
@@ -54,6 +69,15 @@ target_include_directories(aho_corasick_search
 if(ENABLE_SEARCH_STATS)
     target_compile_definitions(aho_corasick_search PUBLIC AHO_CORASICK_SEARCH_STATS)
 endif()
+if(ENABLE_FAILURELESS_FULL_ROWS)
+    target_compile_definitions(aho_corasick_search PUBLIC AHO_CORASICK_FAILURELESS_FULL_ROWS=1)
+else()
+    target_compile_definitions(aho_corasick_search PUBLIC AHO_CORASICK_FAILURELESS_FULL_ROWS=0)
+endif()
+target_compile_definitions(aho_corasick_search PUBLIC
+    AHO_CORASICK_FULL_ROW_MIN_TRANSITIONS=${FULL_ROW_MIN_TRANSITIONS}
+    AHO_CORASICK_FAILURELESS_CACHE_MAX_STATES=${FAILURELESS_CACHE_MAX_STATES}
+)
 
 # Require C++17
 set_target_properties(aho_corasick_search PROPERTIES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ option(ENABLE_COVERAGE "Build tests with code coverage instrumentation" OFF)
 option(ENABLE_SEARCH_STATS "Enable native search instrumentation counters" OFF)
 option(ENABLE_FAILURELESS_FULL_ROWS "Resolve full-row failure transitions at compile time" ON)
 set(FULL_ROW_MIN_TRANSITIONS 4 CACHE STRING "Minimum transition count that stores a non-root row in full format")
+set(SPARSE_FAILURELESS_MAX_TRANSITIONS 0 CACHE STRING "Maximum sparse-row transition count after failureless expansion; 0 disables expansion")
 set(FAILURELESS_CACHE_MAX_STATES 0 CACHE STRING "Maximum states with precomputed failureless transitions; 0 disables the cache")
 
 if("${FULL_ROW_MIN_TRANSITIONS}" MATCHES "^[0-9][0-9]*$")
@@ -17,6 +18,13 @@ else()
 endif()
 if(FULL_ROW_MIN_TRANSITIONS LESS 1 OR FULL_ROW_MIN_TRANSITIONS GREATER 64)
     message(FATAL_ERROR "FULL_ROW_MIN_TRANSITIONS must be an integer from 1 to 64")
+endif()
+if("${SPARSE_FAILURELESS_MAX_TRANSITIONS}" MATCHES "^[0-9][0-9]*$")
+else()
+    message(FATAL_ERROR "SPARSE_FAILURELESS_MAX_TRANSITIONS must be an integer from 0 to 63")
+endif()
+if(SPARSE_FAILURELESS_MAX_TRANSITIONS GREATER 63)
+    message(FATAL_ERROR "SPARSE_FAILURELESS_MAX_TRANSITIONS must be an integer from 0 to 63")
 endif()
 if("${FAILURELESS_CACHE_MAX_STATES}" MATCHES "^[0-9][0-9]*$")
 else()
@@ -76,6 +84,7 @@ else()
 endif()
 target_compile_definitions(aho_corasick_search PUBLIC
     AHO_CORASICK_FULL_ROW_MIN_TRANSITIONS=${FULL_ROW_MIN_TRANSITIONS}
+    AHO_CORASICK_SPARSE_FAILURELESS_MAX_TRANSITIONS=${SPARSE_FAILURELESS_MAX_TRANSITIONS}
     AHO_CORASICK_FAILURELESS_CACHE_MAX_STATES=${FAILURELESS_CACHE_MAX_STATES}
 )
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,37 @@ cmake --build . --target coverage
 
 The generated `gcov` reports are written to `build-coverage/coverage/`.
 
+## Python extension
+
+The project can also build a native CPython extension with
+[nanobind](https://nanobind.readthedocs.io/). This is intended for benchmark
+integration where Python callback overhead would hide the C++ search cost.
+
+Install nanobind into the Python environment used by CMake, then enable the
+extension target:
+
+```sh
+python3 -m pip install nanobind
+cmake -S . -B build-python -DBUILD_PYTHON_EXTENSION=ON -DBUILD_TESTS=ON
+cmake --build build-python
+ctest --test-dir build-python --output-on-failure
+```
+
+The extension module is written to the CMake build directory. For ad hoc use:
+
+```sh
+PYTHONPATH=build-python python3 - <<'PY'
+import aho_corasick_search_ext
+
+ac = aho_corasick_search_ext.AhoCorasick(["needle", "hay"])
+print(ac.find_matches_as_indexes("haystack needle"))
+print(ac.count_matches("haystack needle"))
+PY
+```
+
+The Python API reports byte offsets. This is the fastest path and matches the
+ASCII benchmark data used by `ahocorasick_rs`.
+
 ## Usage example
 
 ```cpp

--- a/README.md
+++ b/README.md
@@ -90,6 +90,21 @@ cmake -S . -B build-python-no-fullrow-resolve \
 cmake --build build-python-no-fullrow-resolve
 ```
 
+The build can also expand sparse rows with inherited failure transitions while
+keeping the rows sparse. This is disabled by default because it can reduce
+failure walks at the cost of longer linear sparse scans:
+
+```sh
+cmake -S . -B build-python-sparse-failureless \
+  -DBUILD_PYTHON_EXTENSION=ON \
+  -DSPARSE_FAILURELESS_MAX_TRANSITIONS=2
+cmake --build build-python-sparse-failureless
+```
+
+With the default `FULL_ROW_MIN_TRANSITIONS=4`, values above `3` have no
+additional effect for sparse rows; tune the full-row threshold separately if
+you want to test larger expanded rows.
+
 The build also supports a dense failureless cache for the first N compiled
 states. This can remove more failure transitions, but it adds
 `N * 256 * sizeof(state)` memory plus an offset table and should be benchmarked
@@ -104,7 +119,8 @@ cmake --build build-python-cache1024
 
 The Python `AhoCorasick` object provides `get_automaton_info()` to inspect
 state count, transition memory, total memory, and the compiled full-row
-threshold, as well as failureless full-row and dense-cache settings.
+threshold, as well as failureless full-row, sparse-expansion, and dense-cache
+settings.
 
 For native search profiling, enable instrumentation counters in a profiling
 build:

--- a/README.md
+++ b/README.md
@@ -64,6 +64,21 @@ PY
 The Python API reports byte offsets. This is the fastest path and matches the
 ASCII benchmark data used by `ahocorasick_rs`.
 
+For native search profiling, enable instrumentation counters in a profiling
+build:
+
+```sh
+cmake -S . -B build-python-stats \
+  -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+  -DBUILD_PYTHON_EXTENSION=ON \
+  -DENABLE_SEARCH_STATS=ON
+cmake --build build-python-stats
+```
+
+When built with `ENABLE_SEARCH_STATS=ON`, the Python `AhoCorasick` object also
+provides `reset_search_stats()` and `get_search_stats()` for inspecting sparse
+NFA transition behavior.
+
 ## Usage example
 
 ```cpp

--- a/README.md
+++ b/README.md
@@ -64,6 +64,48 @@ PY
 The Python API reports byte offsets. This is the fastest path and matches the
 ASCII benchmark data used by `ahocorasick_rs`.
 
+By default, the root row and non-root rows with at least four outgoing
+transitions use full 256-entry storage. This favors search throughput over the
+most compact sparse layout. To tune the speed/memory tradeoff, set the minimum
+transition count for full rows:
+
+```sh
+cmake -S . -B build-python-full8 \
+  -DBUILD_PYTHON_EXTENSION=ON \
+  -DFULL_ROW_MIN_TRANSITIONS=8
+cmake --build build-python-full8
+```
+
+Use `FULL_ROW_MIN_TRANSITIONS=64` to restore the previous compact behavior,
+where only the root row and rows too large for sparse encoding use full
+storage.
+
+Full rows resolve failure transitions at compile time by default. This keeps
+the same transition-table size while avoiding failure walks from full rows:
+
+```sh
+cmake -S . -B build-python-no-fullrow-resolve \
+  -DBUILD_PYTHON_EXTENSION=ON \
+  -DENABLE_FAILURELESS_FULL_ROWS=OFF
+cmake --build build-python-no-fullrow-resolve
+```
+
+The build also supports a dense failureless cache for the first N compiled
+states. This can remove more failure transitions, but it adds
+`N * 256 * sizeof(state)` memory plus an offset table and should be benchmarked
+before use:
+
+```sh
+cmake -S . -B build-python-cache1024 \
+  -DBUILD_PYTHON_EXTENSION=ON \
+  -DFAILURELESS_CACHE_MAX_STATES=1024
+cmake --build build-python-cache1024
+```
+
+The Python `AhoCorasick` object provides `get_automaton_info()` to inspect
+state count, transition memory, total memory, and the compiled full-row
+threshold, as well as failureless full-row and dense-cache settings.
+
 For native search profiling, enable instrumentation counters in a profiling
 build:
 

--- a/examples/python_example.py
+++ b/examples/python_example.py
@@ -1,0 +1,18 @@
+import aho_corasick_search_ext
+
+
+def main() -> None:
+    patterns = ["he", "she", "hers"]
+    haystack = "ushers"
+
+    search = aho_corasick_search_ext.AhoCorasick(patterns)
+
+    print("patterns:", patterns)
+    print("haystack:", haystack)
+    print("matches as indexes:", search.find_matches_as_indexes(haystack))
+    print("matches as strings:", search.find_matches_as_strings(haystack))
+    print("match count:", search.count_matches(haystack))
+
+
+if __name__ == "__main__":
+    main()

--- a/performance_log.md
+++ b/performance_log.md
@@ -1,0 +1,299 @@
+# Performance Log
+
+This log records the benchmark and profiling path used while adding the native
+Python extension and tuning search performance. The goal was to make each
+optimization decision measurement-driven and to separate Python binding overhead
+from core Aho-Corasick search cost.
+
+## Benchmark Setup
+
+The comparison target was the Python benchmark suite from `~/ahocorasick_rs`,
+especially `benchmarks/test_comparison.py`.
+
+Relevant benchmark data:
+
+- Short dataset: 10 patterns, 10,000 haystacks, 748,890 input bytes, 50,000 matches.
+- Long dataset: 4,244 patterns, 100,000 haystacks, 62,984,675 input bytes, 1,605 matches.
+
+We added a nanobind CPython extension in `python/aho_corasick_search_ext.cpp`
+so the benchmark could call this library directly from Python without per-match
+Python callback overhead. The exposed API includes:
+
+- `find_matches_as_indexes(haystack)`
+- `find_matches_as_strings(haystack)`
+- `count_matches(haystack)`
+
+The count-only path was useful because it measures search cost without allocating
+Python result tuples.
+
+## Baseline Python Benchmarks
+
+The first benchmark integrated this extension into the `ahocorasick_rs`
+pytest-benchmark harness and compared overlapping index matches.
+
+Release baseline:
+
+| Dataset | Implementation | Mean Time |
+| --- | --- | ---: |
+| short | this extension, count-only | 1.715 ms |
+| short | this extension, indexes | 3.260 ms |
+| short | `ahocorasick_rs`, indexes | 4.202 ms |
+| long | `ahocorasick_rs`, indexes | 295.456 ms |
+| long | this extension, indexes | 351.483 ms |
+| long | this extension, count-only | 361.819 ms |
+
+Interpretation:
+
+- On the short dataset, this extension was already competitive.
+- On the long dataset, count-only and index-returning benchmarks were close,
+  so Python result allocation was not the main bottleneck.
+- The long-dataset gap pointed at core native search rather than the Python
+  binding layer.
+
+## Native Sampling
+
+We rebuilt with `RelWithDebInfo` and sampled the long count-only benchmark with
+macOS `sample`.
+
+Sample output was written to:
+
+```sh
+/tmp/cpierret-count-long.sample.txt
+```
+
+Key native sampling results:
+
+- `16529 / 17026` samples, about 97%, were inside
+  `_bnfa_search_csparse_nfa_case`.
+- The dominant line was the transition lookup:
+  `src/aho_corasick.h:635`, calling `_bnfa_get_next_state_csparse_nfa`.
+- `PyUnicode_AsUTF8AndSize` accounted for only 12 samples.
+- `std::any` and callback-related samples were negligible in the long sparse
+  match case.
+
+Conclusion:
+
+The important hotspot was the sparse NFA transition loop, not nanobind, Python
+string conversion, result allocation, or `std::any`.
+
+## Search Counters
+
+To quantify the hotspot, we added an opt-in profiling mode:
+
+```sh
+cmake -S . -B build-python-stats \
+  -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+  -DBUILD_PYTHON_EXTENSION=ON \
+  -DENABLE_SEARCH_STATS=ON
+cmake --build build-python-stats
+```
+
+When `ENABLE_SEARCH_STATS=ON`, the Python object exposes:
+
+- `reset_search_stats()`
+- `get_search_stats()`
+
+Baseline long-dataset counters with the original compact layout:
+
+| Counter | Value |
+| --- | ---: |
+| input bytes / transition calls | 62,984,675 |
+| state visits | 108,580,827 |
+| failure transitions | 45,596,152 |
+| full row visits | 29,488,890 |
+| sparse row visits | 79,091,937 |
+| sparse comparisons | 236,267,860 |
+| sparse comparisons per input byte | 3.75 |
+| failure transitions per input byte | 0.724 |
+| match candidates | 1,605 |
+
+Interpretation:
+
+- Search visits about 1.72 states per input byte because failure transitions are
+  common.
+- Most state visits are sparse rows.
+- Sparse lookup performs hundreds of millions of comparisons.
+- Match handling is not material for this dataset.
+
+This split suggested two independent optimization directions:
+
+1. Reduce sparse transition lookup cost.
+2. Reduce failure-link traversal with a cached or failureless transition path.
+
+We tuned the first option before considering the second.
+
+## Full-Row Threshold Tuning
+
+The compact sparse representation originally used full 256-entry rows only for:
+
+- the root row, and
+- rows with more than 63 outgoing transitions, because they cannot fit in the
+  sparse row count field.
+
+That is compact, but high-fanout sparse rows still pay binary or linear search
+cost on every visit. We added a CMake cache setting:
+
+```sh
+FULL_ROW_MIN_TRANSITIONS
+```
+
+This controls when non-root rows use full 256-entry storage. Lower values spend
+more memory to replace sparse lookup with direct indexing.
+
+Example:
+
+```sh
+cmake -S . -B build-python-full8 \
+  -DBUILD_PYTHON_EXTENSION=ON \
+  -DFULL_ROW_MIN_TRANSITIONS=8
+cmake --build build-python-full8
+```
+
+The Python object now also exposes `get_automaton_info()` so benchmark scripts
+can report state count, transition memory, total memory, and the compiled
+threshold.
+
+## Threshold Sweep
+
+We swept thresholds with Release builds, then ran focused pytest-benchmark
+checks for the most useful candidates.
+
+Long count-path sweep:
+
+| Threshold | Mean Time | Transition Memory |
+| ---: | ---: | ---: |
+| 64 | 379.8 ms | 269 KB |
+| 8 | 262.1 ms | 433 KB |
+| 4 | 232.0 ms | 1.03 MB |
+| 1 | worse than threshold 4 | 15.6 MB |
+
+Focused long overlapping-index benchmark at threshold 4:
+
+| Implementation | Mean Time |
+| --- | ---: |
+| this extension, `FULL_ROW_MIN_TRANSITIONS=4` | 231.8 ms |
+| `ahocorasick_rs`, overlapping indexes | 311.4 ms |
+
+Counters confirmed the effect was isolated to sparse lookup cost:
+
+| Threshold | Sparse Comparisons | Transition Memory |
+| ---: | ---: | ---: |
+| 64 | 236,267,860 | 269,744 bytes |
+| 12 | 178,777,411 | 317,960 bytes |
+| 8 | 136,280,017 | 432,600 bytes |
+| 4 | 33,697,470 | 1,033,360 bytes |
+| 1 | 0 | 15,610,288 bytes |
+
+Failure transitions stayed fixed at `45,596,152`, which means this knob only
+changes row lookup cost. It does not hide or solve failure-link traversal.
+
+## Decision
+
+We set the default full-row threshold to `4`.
+
+Rationale:
+
+- It gave the best focused benchmark result among the tested thresholds.
+- It reduced sparse comparisons by about 86% versus the compact baseline.
+- It improved long-dataset overlapping-index throughput enough to beat the
+  `ahocorasick_rs` benchmark run used for comparison.
+- The transition table grew to about 1 MB on the long dataset, which is a
+  reasonable tradeoff for this benchmark profile.
+- Threshold `1` removed sparse comparisons entirely but used far more memory and
+  did not improve timing, likely because cache pressure outweighed lookup gains.
+
+To restore the old compact behavior, configure with:
+
+```sh
+-DFULL_ROW_MIN_TRANSITIONS=64
+```
+
+## Failureless Transition Path
+
+The next independent optimization was failure traversal.
+
+The full-row threshold reduced sparse lookup comparisons, but the long dataset
+still performs `45,596,152` failure transitions, about `0.724` per input byte.
+A selective cached or failureless transition path could precompute the final
+transition for hot `(state, byte)` pairs or hot states, turning repeated failure
+walks into direct lookups.
+
+We implemented two variants and kept them separately configurable:
+
+1. In-place failureless full rows.
+2. A dense failureless cache for the first N compiled states.
+
+### In-Place Full Rows
+
+Full rows already spend 256 entries per state. We can therefore resolve missing
+full-row transitions during compilation without increasing transition-table
+memory. For each non-root full row, zero entries are replaced with the state that
+would be reached after following failure links.
+
+This is enabled by default:
+
+```sh
+-DENABLE_FAILURELESS_FULL_ROWS=ON
+```
+
+Use this to restore the old behavior:
+
+```sh
+-DENABLE_FAILURELESS_FULL_ROWS=OFF
+```
+
+Long-dataset stats with `FULL_ROW_MIN_TRANSITIONS=4` and in-place full-row
+resolution:
+
+| Counter | Value |
+| --- | ---: |
+| input bytes / transition calls | 62,984,675 |
+| state visits | 77,583,296 |
+| failure transitions | 14,598,621 |
+| full row visits | 58,882,778 |
+| sparse row visits | 18,700,518 |
+| sparse comparisons | 32,897,409 |
+| dense cache memory | 0 bytes |
+| transition memory | 1,033,360 bytes |
+
+Focused long overlapping-index benchmark:
+
+| Implementation | Mean Time |
+| --- | ---: |
+| this extension, threshold 4 + failureless full rows | 180.4 ms |
+| `ahocorasick_rs`, overlapping indexes | 316.8 ms |
+
+This was the best result so far because it removed about 31 million failure
+transitions without adding a second large transition table.
+
+### Dense Failureless Cache
+
+The dense cache precomputes 256 final transitions for up to
+`FAILURELESS_CACHE_MAX_STATES` states:
+
+```sh
+-DFAILURELESS_CACHE_MAX_STATES=1024
+```
+
+`0` disables the dense cache and is the default.
+
+The full dense cache removed all failure transitions on the long dataset:
+
+| Counter | Value |
+| --- | ---: |
+| cached states | 11,163 |
+| failure transitions | 0 |
+| cache hits | 62,984,675 |
+| cache memory | 23,895,184 bytes |
+
+However, it was slower in the focused long overlapping-index benchmark:
+
+| Configuration | Mean Time |
+| --- | ---: |
+| threshold 4 + failureless full rows | 180.4 ms |
+| threshold 4 + failureless full rows + full dense cache | 287.1 ms |
+
+The dense cache removes more algorithmic work, but its larger random-access
+table adds enough memory pressure to lose on this benchmark. It remains useful
+as an opt-in experiment for other pattern sets or machines, but it should not be
+enabled by default based on the current evidence.

--- a/performance_log.md
+++ b/performance_log.md
@@ -218,10 +218,11 @@ A selective cached or failureless transition path could precompute the final
 transition for hot `(state, byte)` pairs or hot states, turning repeated failure
 walks into direct lookups.
 
-We implemented two variants and kept them separately configurable:
+We implemented three variants and kept them separately configurable:
 
 1. In-place failureless full rows.
-2. A dense failureless cache for the first N compiled states.
+2. Bounded sparse-row failureless expansion.
+3. A dense failureless cache for the first N compiled states.
 
 ### In-Place Full Rows
 
@@ -265,6 +266,51 @@ Focused long overlapping-index benchmark:
 
 This was the best result so far because it removed about 31 million failure
 transitions without adding a second large transition table.
+
+### Bounded Sparse-Row Expansion
+
+After abandoning hot-state selective caching as too workload-specific, we tried
+a structure-based variant for sparse rows. During compilation, before compaction
+into sparse/full rows, each sparse row can inherit transitions from its failure
+chain until it reaches a configured cap:
+
+```sh
+-DSPARSE_FAILURELESS_MAX_TRANSITIONS=2
+```
+
+`0` disables the expansion and remains the default. With the current
+`FULL_ROW_MIN_TRANSITIONS=4`, cap `3` is the largest value that keeps the rows
+sparse and isolates this knob from full-row threshold tuning.
+
+Long-dataset direct timing sweep:
+
+| Sparse Cap | Count Median | Index Median | Transition Memory |
+| ---: | ---: | ---: | ---: |
+| 0 | 184.5 ms | 183.6 ms | 1,033,360 bytes |
+| 1 | 184.5 ms | 183.4 ms | 1,062,384 bytes |
+| 2 | 179.1 ms | 182.9 ms | 1,138,208 bytes |
+| 3 | 188.6 ms | 185.0 ms | 1,221,712 bytes |
+
+Stats explain why the result is weak:
+
+| Sparse Cap | Failure Transitions | Sparse Comparisons | State Visits |
+| ---: | ---: | ---: | ---: |
+| 0 | 14,598,621 | 32,897,409 | 77,583,296 |
+| 1 | 14,598,621 | 32,898,535 | 77,583,296 |
+| 2 | 14,199,733 | 41,100,511 | 77,184,408 |
+| 3 | 14,099,733 | 54,002,268 | 77,084,408 |
+
+The expansion is structurally valid and cap `2` passed sorted correctness checks
+against `ahocorasick_rs` on the short and long datasets. However, the extra
+inherited transitions make every sparse-row visit scan longer rows. On this
+workload, the added linear scan cost mostly cancels out the smaller failure
+walk count.
+
+Decision:
+
+- Keep `SPARSE_FAILURELESS_MAX_TRANSITIONS` as an opt-in experiment.
+- Do not enable it by default without another workload where the failure-walk
+  reduction clearly outweighs the longer sparse scans.
 
 ### Dense Failureless Cache
 

--- a/python/aho_corasick_search_ext.cpp
+++ b/python/aho_corasick_search_ext.cpp
@@ -269,6 +269,8 @@ public:
             textsearch::AhoCorasickSearch::getFullRowMinTransitions();
         result["failureless_full_rows"] =
             textsearch::AhoCorasickSearch::hasFailurelessFullRows();
+        result["sparse_failureless_max_transitions"] =
+            textsearch::AhoCorasickSearch::getSparseFailurelessMaxTransitions();
         result["failureless_cache_max_states"] =
             textsearch::AhoCorasickSearch::getFailurelessCacheMaxStates();
         return result;

--- a/python/aho_corasick_search_ext.cpp
+++ b/python/aho_corasick_search_ext.cpp
@@ -1,0 +1,258 @@
+#include "aho_corasick.h"
+
+#include <Python.h>
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/string.h>
+#include <nanobind/stl/tuple.h>
+#include <nanobind/stl/vector.h>
+
+#include <cstddef>
+#include <stdexcept>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+namespace nb = nanobind;
+using namespace nb::literals;
+
+namespace {
+
+class HaystackView {
+public:
+    explicit HaystackView(nb::handle haystack)
+    {
+        PyObject* object = haystack.ptr();
+
+        if (PyUnicode_Check(object))
+        {
+            Py_ssize_t size = 0;
+            const char* data = PyUnicode_AsUTF8AndSize(object, &size);
+            if (!data)
+            {
+                throw nb::python_error();
+            }
+            data_ = data;
+            size_ = size;
+            return;
+        }
+
+        if (PyBytes_Check(object))
+        {
+            char* data = nullptr;
+            Py_ssize_t size = 0;
+            if (PyBytes_AsStringAndSize(object, &data, &size) < 0)
+            {
+                throw nb::python_error();
+            }
+            data_ = data;
+            size_ = size;
+            return;
+        }
+
+        if (PyObject_GetBuffer(object, &buffer_, PyBUF_SIMPLE) == 0)
+        {
+            owns_buffer_ = true;
+            data_ = static_cast<const char*>(buffer_.buf);
+            size_ = buffer_.len;
+            return;
+        }
+
+        PyErr_Clear();
+        throw nb::type_error("haystack must be str, bytes, or a contiguous bytes-like object");
+    }
+
+    HaystackView(const HaystackView&) = delete;
+    HaystackView& operator=(const HaystackView&) = delete;
+
+    ~HaystackView()
+    {
+        if (owns_buffer_)
+        {
+            PyBuffer_Release(&buffer_);
+        }
+    }
+
+    const char* begin() const
+    {
+        return data_;
+    }
+
+    const char* end() const
+    {
+        return data_ + size_;
+    }
+
+private:
+    Py_buffer buffer_ {};
+    bool owns_buffer_ = false;
+    const char* data_ = nullptr;
+    Py_ssize_t size_ = 0;
+};
+
+using MatchTuple = std::tuple<std::size_t, int, int>;
+
+struct IndexMatchCollector {
+    const std::vector<std::size_t>* pattern_lengths = nullptr;
+    std::vector<MatchTuple> matches;
+};
+
+struct PatternMatchCollector {
+    std::vector<std::size_t> pattern_ids;
+};
+
+int collect_index_match(
+    textsearch::AhoCorasickSearch::any_t pattern_userdata,
+    int index,
+    textsearch::AhoCorasickSearch::any_t search_userdata)
+{
+    auto* collector = std::any_cast<IndexMatchCollector*>(search_userdata);
+    const auto pattern_id = std::any_cast<std::size_t>(pattern_userdata);
+    const auto length = collector->pattern_lengths->at(pattern_id);
+    collector->matches.emplace_back(pattern_id, index, index + static_cast<int>(length));
+    return 0;
+}
+
+int collect_pattern_match(
+    textsearch::AhoCorasickSearch::any_t pattern_userdata,
+    int,
+    textsearch::AhoCorasickSearch::any_t search_userdata)
+{
+    auto* collector = std::any_cast<PatternMatchCollector*>(search_userdata);
+    collector->pattern_ids.push_back(std::any_cast<std::size_t>(pattern_userdata));
+    return 0;
+}
+
+int count_match(
+    textsearch::AhoCorasickSearch::any_t,
+    int,
+    textsearch::AhoCorasickSearch::any_t search_userdata)
+{
+    auto* count = std::any_cast<std::size_t*>(search_userdata);
+    ++(*count);
+    return 0;
+}
+
+class PyAhoCorasick {
+public:
+    explicit PyAhoCorasick(const std::vector<std::string>& patterns)
+        : patterns_(patterns),
+          search_(textsearch::AhoCorasickSearch::bnfa_case::BNFA_CASE)
+    {
+        if (patterns_.empty())
+        {
+            throw nb::value_error("at least one pattern is required");
+        }
+
+        pattern_lengths_.reserve(patterns_.size());
+        for (std::size_t index = 0; index < patterns_.size(); ++index)
+        {
+            const std::string& pattern = patterns_[index];
+            if (pattern.empty())
+            {
+                throw nb::value_error("empty patterns are not supported");
+            }
+            pattern_lengths_.push_back(pattern.size());
+            if (search_.addPattern(pattern.begin(), pattern.end(), false, index) != 0)
+            {
+                throw std::runtime_error("failed to add pattern");
+            }
+        }
+
+        if (search_.compile() != 0)
+        {
+            throw std::runtime_error("failed to compile automaton");
+        }
+    }
+
+    std::vector<MatchTuple> find_matches_as_indexes(nb::handle haystack)
+    {
+        HaystackView view(haystack);
+        IndexMatchCollector collector;
+        collector.pattern_lengths = &pattern_lengths_;
+
+        {
+            nb::gil_scoped_release release;
+            textsearch::AhoCorasickSearch::bnfa_state_index_t state = 0;
+            search_.search(
+                view.begin(),
+                view.end(),
+                collect_index_match,
+                &collector,
+                0,
+                &state);
+        }
+
+        return std::move(collector.matches);
+    }
+
+    std::vector<std::string> find_matches_as_strings(nb::handle haystack)
+    {
+        HaystackView view(haystack);
+        PatternMatchCollector collector;
+
+        {
+            nb::gil_scoped_release release;
+            textsearch::AhoCorasickSearch::bnfa_state_index_t state = 0;
+            search_.search(
+                view.begin(),
+                view.end(),
+                collect_pattern_match,
+                &collector,
+                0,
+                &state);
+        }
+
+        std::vector<std::string> matches;
+        matches.reserve(collector.pattern_ids.size());
+        for (std::size_t pattern_id : collector.pattern_ids)
+        {
+            matches.push_back(patterns_.at(pattern_id));
+        }
+        return matches;
+    }
+
+    std::size_t count_matches(nb::handle haystack)
+    {
+        HaystackView view(haystack);
+        std::size_t count = 0;
+
+        {
+            nb::gil_scoped_release release;
+            textsearch::AhoCorasickSearch::bnfa_state_index_t state = 0;
+            search_.search(view.begin(), view.end(), count_match, &count, 0, &state);
+        }
+
+        return count;
+    }
+
+private:
+    std::vector<std::string> patterns_;
+    std::vector<std::size_t> pattern_lengths_;
+    textsearch::AhoCorasickSearch search_;
+};
+
+} // namespace
+
+NB_MODULE(aho_corasick_search_ext, module)
+{
+    module.doc() = "Native CPython bindings for AhoCorasickSearch.";
+
+    nb::class_<PyAhoCorasick>(module, "AhoCorasick")
+        .def(nb::init<const std::vector<std::string>&>(), "patterns"_a)
+        .def(
+            "find_matches_as_indexes",
+            &PyAhoCorasick::find_matches_as_indexes,
+            "haystack"_a,
+            "Return (pattern_index, start_byte, end_byte) tuples.")
+        .def(
+            "find_matches_as_strings",
+            &PyAhoCorasick::find_matches_as_strings,
+            "haystack"_a,
+            "Return matched pattern strings.")
+        .def(
+            "count_matches",
+            &PyAhoCorasick::count_matches,
+            "haystack"_a,
+            "Return the number of matches without allocating match result tuples.");
+}

--- a/python/aho_corasick_search_ext.cpp
+++ b/python/aho_corasick_search_ext.cpp
@@ -154,6 +154,8 @@ nb::dict search_stats_to_dict(const textsearch::AhoCorasickSearch::SearchStats& 
     result["sparse_binary_hits"] = stats.sparse_binary_hits;
     result["sparse_binary_misses"] = stats.sparse_binary_misses;
     result["failure_transitions"] = stats.failure_transitions;
+    result["failureless_cache_hits"] = stats.failureless_cache_hits;
+    result["failureless_cache_misses"] = stats.failureless_cache_misses;
     result["match_state_checks"] = stats.match_state_checks;
     result["match_state_hits"] = stats.match_state_hits;
     result["match_candidates"] = stats.match_candidates;
@@ -254,6 +256,24 @@ public:
         return count;
     }
 
+    nb::dict get_automaton_info() const
+    {
+        nb::dict result;
+        result["pattern_count"] = search_.getPatternCount();
+        result["state_count"] = search_.getStateCount();
+        result["transition_memory_bytes"] = search_.getTransitionMemoryBytes();
+        result["failureless_cache_memory_bytes"] = search_.getFailurelessCacheMemoryBytes();
+        result["failureless_cache_state_count"] = search_.getFailurelessCacheStateCount();
+        result["total_memory_bytes"] = search_.getTotalMemoryBytes();
+        result["full_row_min_transitions"] =
+            textsearch::AhoCorasickSearch::getFullRowMinTransitions();
+        result["failureless_full_rows"] =
+            textsearch::AhoCorasickSearch::hasFailurelessFullRows();
+        result["failureless_cache_max_states"] =
+            textsearch::AhoCorasickSearch::getFailurelessCacheMaxStates();
+        return result;
+    }
+
 #ifdef AHO_CORASICK_SEARCH_STATS
     void reset_search_stats()
     {
@@ -295,6 +315,10 @@ NB_MODULE(aho_corasick_search_ext, module)
             &PyAhoCorasick::count_matches,
             "haystack"_a,
             "Return the number of matches without allocating match result tuples.")
+        .def(
+            "get_automaton_info",
+            &PyAhoCorasick::get_automaton_info,
+            "Return compiled automaton size and layout information.")
 #ifdef AHO_CORASICK_SEARCH_STATS
         .def(
             "reset_search_stats",

--- a/python/aho_corasick_search_ext.cpp
+++ b/python/aho_corasick_search_ext.cpp
@@ -133,6 +133,34 @@ int count_match(
     return 0;
 }
 
+#ifdef AHO_CORASICK_SEARCH_STATS
+nb::dict search_stats_to_dict(const textsearch::AhoCorasickSearch::SearchStats& stats)
+{
+    nb::dict result;
+    result["transition_calls"] = stats.transition_calls;
+    result["state_visits"] = stats.state_visits;
+    result["full_row_visits"] = stats.full_row_visits;
+    result["full_root_transitions"] = stats.full_root_transitions;
+    result["full_root_zero_transitions"] = stats.full_root_zero_transitions;
+    result["full_non_root_hits"] = stats.full_non_root_hits;
+    result["full_non_root_misses"] = stats.full_non_root_misses;
+    result["sparse_row_visits"] = stats.sparse_row_visits;
+    result["sparse_linear_rows"] = stats.sparse_linear_rows;
+    result["sparse_linear_comparisons"] = stats.sparse_linear_comparisons;
+    result["sparse_linear_hits"] = stats.sparse_linear_hits;
+    result["sparse_linear_misses"] = stats.sparse_linear_misses;
+    result["sparse_binary_rows"] = stats.sparse_binary_rows;
+    result["sparse_binary_comparisons"] = stats.sparse_binary_comparisons;
+    result["sparse_binary_hits"] = stats.sparse_binary_hits;
+    result["sparse_binary_misses"] = stats.sparse_binary_misses;
+    result["failure_transitions"] = stats.failure_transitions;
+    result["match_state_checks"] = stats.match_state_checks;
+    result["match_state_hits"] = stats.match_state_hits;
+    result["match_candidates"] = stats.match_candidates;
+    return result;
+}
+#endif
+
 class PyAhoCorasick {
 public:
     explicit PyAhoCorasick(const std::vector<std::string>& patterns)
@@ -226,6 +254,18 @@ public:
         return count;
     }
 
+#ifdef AHO_CORASICK_SEARCH_STATS
+    void reset_search_stats()
+    {
+        search_.resetSearchStats();
+    }
+
+    nb::dict get_search_stats() const
+    {
+        return search_stats_to_dict(search_.getSearchStats());
+    }
+#endif
+
 private:
     std::vector<std::string> patterns_;
     std::vector<std::size_t> pattern_lengths_;
@@ -254,5 +294,16 @@ NB_MODULE(aho_corasick_search_ext, module)
             "count_matches",
             &PyAhoCorasick::count_matches,
             "haystack"_a,
-            "Return the number of matches without allocating match result tuples.");
+            "Return the number of matches without allocating match result tuples.")
+#ifdef AHO_CORASICK_SEARCH_STATS
+        .def(
+            "reset_search_stats",
+            &PyAhoCorasick::reset_search_stats,
+            "Reset native search instrumentation counters.")
+        .def(
+            "get_search_stats",
+            &PyAhoCorasick::get_search_stats,
+            "Return native search instrumentation counters.")
+#endif
+        ;
 }

--- a/src/aho_corasick.cc
+++ b/src/aho_corasick.cc
@@ -592,9 +592,7 @@ AhoCorasickSearch::_bnfa_conv_list_to_csparse_array()
         }
 
         /* add in transition count */
-        if ((k == 0 && bnfaForceFullZeroState)
-            || nc > BNFA_SPARSE_MAX_ROW_TRANSITIONS
-            )
+        if (shouldUseFullFormatForRow(k, nc, bnfaForceFullZeroState))
         {
             nps += BNFA_MAX_ALPHABET_SIZE;
         }
@@ -653,8 +651,7 @@ AhoCorasickSearch::_bnfa_conv_list_to_csparse_array()
         }
 
         /* add a full state or a sparse state  */
-        if ((k == 0 && bnfaForceFullZeroState) ||
-            nc > BNFA_SPARSE_MAX_ROW_TRANSITIONS)
+        if (shouldUseFullFormatForRow(k, nc, bnfaForceFullZeroState))
         {
             // Full format
             /* set the control word */
@@ -772,6 +769,161 @@ AhoCorasickSearch::_bnfa_conv_list_to_csparse_array()
 
     bnfaTransList = std::move(transition_list);
     nextstate_memory = bnfaTransList.size() * sizeof(bnfa_state_t);
+
+#if AHO_CORASICK_FAILURELESS_FULL_ROWS
+    if (_resolve_full_row_failure_transitions() < 0)
+    {
+        return -1;
+    }
+#endif
+
+#if AHO_CORASICK_FAILURELESS_CACHE_MAX_STATES > 0
+    if (_build_failureless_transition_cache(state_indexes) < 0)
+    {
+        return -1;
+    }
+#else
+    failureless_cache_memory = 0;
+#endif
+
+    return 0;
+}
+
+int
+AhoCorasickSearch::_resolve_full_row_failure_transitions()
+{
+    if (bnfaTransList.empty())
+    {
+        return 0;
+    }
+
+    bnfa_state_t* ps = bnfaTransList.data();
+    bnfa_state_index_t ps_index = 0;
+#ifdef AHO_CORASICK_SEARCH_STATS
+    SearchStats build_stats;
+#endif
+
+    for (bnfa_state_index_t state = 0; state < bnfaNumStates; ++state)
+    {
+        if (ps_index >= bnfaTransList.size())
+        {
+            return -1;
+        }
+
+        ++ps_index; /* skip state id */
+        if (ps_index >= bnfaTransList.size())
+        {
+            return -1;
+        }
+
+        bnfa_state_t& control = ps[ps_index];
+        if (isFullFormat(control))
+        {
+            const bnfa_state_index_t failure_state = getFailureState(control);
+            ++ps_index;
+
+            if (ps_index + BNFA_MAX_ALPHABET_SIZE > bnfaTransList.size())
+            {
+                return -1;
+            }
+
+            if (state != 0)
+            {
+                for (unsigned input = 0; input < BNFA_MAX_ALPHABET_SIZE; ++input)
+                {
+                    bnfa_state_t& transition = ps[ps_index + input];
+                    if (fullGetTransitionState(transition) == 0)
+                    {
+                        const bnfa_state_index_t resolved_state =
+                            _bnfa_get_next_state_csparse_nfa(
+                                ps,
+                                failure_state,
+                                input
+#ifdef AHO_CORASICK_SEARCH_STATS
+                                , &build_stats
+#endif
+                                );
+                        transition = makeTransitionState(transition, resolved_state);
+                    }
+                }
+            }
+
+            ps_index += BNFA_MAX_ALPHABET_SIZE;
+        }
+        else
+        {
+            const unsigned nc = sparseGetNumberOfTransitions(control);
+            ++ps_index;
+            ps_index += nc;
+        }
+    }
+
+    return ps_index == bnfaTransList.size() ? 0 : -1;
+}
+
+int
+AhoCorasickSearch::_build_failureless_transition_cache(
+    const std::vector<bnfa_state_index_t>& state_indexes)
+{
+#if AHO_CORASICK_FAILURELESS_CACHE_MAX_STATES > 0
+    const size_t cache_state_count =
+        state_indexes.size() < BNFA_FAILURELESS_CACHE_MAX_STATES
+            ? state_indexes.size()
+            : BNFA_FAILURELESS_CACHE_MAX_STATES;
+
+    if (cache_state_count == 0)
+    {
+        failureless_cache_offsets_.clear();
+        failureless_transition_cache_.clear();
+        failureless_cache_memory = 0;
+        return 0;
+    }
+
+    try
+    {
+        failureless_cache_offsets_.assign(bnfaTransList.size(), 0);
+        failureless_transition_cache_.clear();
+        failureless_transition_cache_.reserve(cache_state_count * BNFA_MAX_ALPHABET_SIZE);
+
+        bnfa_state_t* transList = bnfaTransList.data();
+#ifdef AHO_CORASICK_SEARCH_STATS
+        SearchStats build_stats;
+#endif
+        for (size_t state = 0; state < cache_state_count; ++state)
+        {
+            const bnfa_state_index_t state_index = state_indexes[state];
+            if (state_index >= failureless_cache_offsets_.size())
+            {
+                return -1;
+            }
+
+            failureless_cache_offsets_[state_index] = failureless_transition_cache_.size() + 1;
+            for (unsigned input = 0; input < BNFA_MAX_ALPHABET_SIZE; ++input)
+            {
+                failureless_transition_cache_.push_back(
+                    _bnfa_get_next_state_csparse_nfa(
+                        transList,
+                        state_index,
+                        input
+#ifdef AHO_CORASICK_SEARCH_STATS
+                        , &build_stats
+#endif
+                        ));
+            }
+        }
+    }
+    catch (const std::bad_alloc&)
+    {
+        return -1;
+    }
+
+    failureless_cache_memory =
+        failureless_cache_offsets_.size() * sizeof(size_t) +
+        failureless_transition_cache_.size() * sizeof(bnfa_state_index_t);
+#else
+    (void)state_indexes;
+    failureless_cache_memory = 0;
+#endif
 
     return 0;
 }
@@ -906,6 +1058,7 @@ AhoCorasickSearch::AhoCorasickSearch(bnfa_case flag)
     pat_memory = 0;
     list_memory = 0;
     nextstate_memory = 0;
+    failureless_cache_memory = 0;
     failstate_memory = 0;
     matchlist_memory = 0;
     setCase(flag);
@@ -934,6 +1087,8 @@ AhoCorasickSearch::_reset_compiled_state()
     std::vector<std::unique_ptr<bnfa_match_node_t>>().swap(match_node_storage_);
     std::vector<bnfa_state_index_t>().swap(bnfaFailState);
     std::vector<bnfa_state_t>().swap(bnfaTransList);
+    std::vector<size_t>().swap(failureless_cache_offsets_);
+    std::vector<bnfa_state_index_t>().swap(failureless_transition_cache_);
     match_queue.clear();
 
     bnfaNumStates = 0;
@@ -944,6 +1099,7 @@ AhoCorasickSearch::_reset_compiled_state()
     matchlist_memory = 0;
     failstate_memory = 0;
     nextstate_memory = 0;
+    failureless_cache_memory = 0;
 }
 
 AhoCorasickSearch::bnfa_trans_node_t*
@@ -1115,9 +1271,41 @@ AhoCorasickSearch::_add_queue(bnfa_match_node_t * p, int pos)
 
 
 int
-AhoCorasickSearch::getPatternCount()
+AhoCorasickSearch::getPatternCount() const
 {
     return bnfaPatternCnt;
+}
+
+auto
+AhoCorasickSearch::getStateCount() const -> bnfa_state_index_t
+{
+    return bnfaNumStates;
+}
+
+size_t
+AhoCorasickSearch::getTransitionMemoryBytes() const
+{
+    return nextstate_memory;
+}
+
+size_t
+AhoCorasickSearch::getFailurelessCacheMemoryBytes() const
+{
+    return failureless_cache_memory;
+}
+
+size_t
+AhoCorasickSearch::getFailurelessCacheStateCount() const
+{
+    return failureless_transition_cache_.size() / BNFA_MAX_ALPHABET_SIZE;
+}
+
+size_t
+AhoCorasickSearch::getTotalMemoryBytes() const
+{
+    return bnfa_memory + pat_memory + list_memory +
+        matchlist_memory + failstate_memory + nextstate_memory +
+        failureless_cache_memory;
 }
 
 
@@ -1146,6 +1334,7 @@ void AhoCorasickSearch::printInfoEx(char * text)
         LogMessage("|   Patterns       :   %.2fK\n", (double)pat_memory / 1024);
         LogMessage("|   Match Lists    :   %.2fK\n", (double)matchlist_memory / 1024);
         LogMessage("|   Transitions    :   %.2fK\n", (double)nextstate_memory / 1024);
+        LogMessage("|   Failureless    :   %.2fK\n", (double)failureless_cache_memory / 1024);
     }
     else
     {
@@ -1157,6 +1346,8 @@ void AhoCorasickSearch::printInfoEx(char * text)
             static_cast<double>(matchlist_memory) / (1024 * 1024));
         LogMessage("|   Transitions    :   %.2fM\n",
             static_cast<double>(nextstate_memory) / (1024 * 1024));
+        LogMessage("|   Failureless    :   %.2fM\n",
+            static_cast<double>(failureless_cache_memory) / (1024 * 1024));
     }
     LogMessage("+-------------------------------------------------\n");
 }

--- a/src/aho_corasick.cc
+++ b/src/aho_corasick.cc
@@ -538,6 +538,94 @@ AhoCorasickSearch::_bnfa_build_nfa()
     return 0;
 }
 
+AhoCorasickSearch::bnfa_state_index_t
+AhoCorasickSearch::_bnfa_list_get_next_state_follow_failure(
+    bnfa_state_index_t state,
+    unsigned char input)
+{
+    for (;;)
+    {
+        const bnfa_state_index_t next = _bnfa_list_get_next_state(state, input);
+        if (next != BNFA_FAIL_STATE)
+        {
+            return next;
+        }
+
+        state = bnfaFailState[state];
+    }
+}
+
+int
+AhoCorasickSearch::_expand_sparse_failure_transitions()
+{
+    if (BNFA_SPARSE_FAILURELESS_MAX_TRANSITIONS == 0)
+    {
+        return 0;
+    }
+
+    const unsigned max_sparse_transitions =
+        BNFA_SPARSE_FAILURELESS_MAX_TRANSITIONS < BNFA_FULL_ROW_MIN_TRANSITIONS
+            ? BNFA_SPARSE_FAILURELESS_MAX_TRANSITIONS
+            : BNFA_FULL_ROW_MIN_TRANSITIONS - 1;
+    if (max_sparse_transitions == 0)
+    {
+        return 0;
+    }
+
+    bnfa_state_t full[BNFA_MAX_ALPHABET_SIZE];
+
+    for (bnfa_state_index_t state = 1; state < bnfaNumStates; ++state)
+    {
+        ptrdiff_t transition_count = _bnfa_list_conv_row_to_full(state, full);
+        if (transition_count < 0)
+        {
+            return -1;
+        }
+
+        if (static_cast<unsigned>(transition_count) >= max_sparse_transitions ||
+            shouldUseFullFormatForRow(
+                state,
+                static_cast<unsigned>(transition_count),
+                bnfaForceFullZeroState))
+        {
+            continue;
+        }
+
+        const bnfa_state_index_t failure_state = bnfaFailState[state];
+        for (unsigned input = 0;
+             input < BNFA_MAX_ALPHABET_SIZE &&
+                static_cast<unsigned>(transition_count) < max_sparse_transitions;
+             ++input)
+        {
+            if (full[input] != 0)
+            {
+                continue;
+            }
+
+            const bnfa_state_index_t resolved_state =
+                _bnfa_list_get_next_state_follow_failure(
+                    failure_state,
+                    static_cast<unsigned char>(input));
+            if (resolved_state == 0)
+            {
+                continue;
+            }
+
+            if (_bnfa_list_put_next_state(
+                    state,
+                    static_cast<unsigned char>(input),
+                    resolved_state) < 0)
+            {
+                return -1;
+            }
+            full[input] = resolved_state;
+            ++transition_count;
+        }
+    }
+
+    return 0;
+}
+
 
 /*
 *  Convert state machine to csparse format
@@ -1195,6 +1283,11 @@ AhoCorasickSearch::compile()
 
         /* Build the nfa w/failure states - time the nfa construction */
         if (_bnfa_build_nfa())
+        {
+            return fail();
+        }
+
+        if (_expand_sparse_failure_transitions())
         {
             return fail();
         }

--- a/src/aho_corasick.h
+++ b/src/aho_corasick.h
@@ -81,6 +81,10 @@
 #define AHO_CORASICK_FAILURELESS_CACHE_MAX_STATES 0
 #endif
 
+#ifndef AHO_CORASICK_SPARSE_FAILURELESS_MAX_TRANSITIONS
+#define AHO_CORASICK_SPARSE_FAILURELESS_MAX_TRANSITIONS 0
+#endif
+
 #ifndef AHO_CORASICK_FAILURELESS_FULL_ROWS
 #define AHO_CORASICK_FAILURELESS_FULL_ROWS 1
 #endif
@@ -197,6 +201,10 @@ public:
     {
         return BNFA_FAILURELESS_CACHE_MAX_STATES;
     }
+    static constexpr unsigned getSparseFailurelessMaxTransitions()
+    {
+        return BNFA_SPARSE_FAILURELESS_MAX_TRANSITIONS;
+    }
     static constexpr bool hasFailurelessFullRows()
     {
         return BNFA_FAILURELESS_FULL_ROWS;
@@ -258,6 +266,8 @@ private:
     static constexpr unsigned BNFA_MAX_ALPHABET_SIZE = 256;
     static constexpr unsigned BNFA_FULL_ROW_MIN_TRANSITIONS =
         AHO_CORASICK_FULL_ROW_MIN_TRANSITIONS;
+    static constexpr unsigned BNFA_SPARSE_FAILURELESS_MAX_TRANSITIONS =
+        AHO_CORASICK_SPARSE_FAILURELESS_MAX_TRANSITIONS;
     static constexpr size_t BNFA_FAILURELESS_CACHE_MAX_STATES =
         AHO_CORASICK_FAILURELESS_CACHE_MAX_STATES;
     static constexpr bool BNFA_FAILURELESS_FULL_ROWS =
@@ -266,6 +276,9 @@ private:
         BNFA_FULL_ROW_MIN_TRANSITIONS >= 1 &&
             BNFA_FULL_ROW_MIN_TRANSITIONS <= BNFA_SPARSE_MAX_ROW_TRANSITIONS + 1,
         "AHO_CORASICK_FULL_ROW_MIN_TRANSITIONS must be between 1 and 64");
+    static_assert(
+        BNFA_SPARSE_FAILURELESS_MAX_TRANSITIONS <= BNFA_SPARSE_MAX_ROW_TRANSITIONS,
+        "AHO_CORASICK_SPARSE_FAILURELESS_MAX_TRANSITIONS must be between 0 and 63");
 
  
     /*
@@ -451,6 +464,10 @@ private:
     int _bnfa_add_pattern_states(bnfa_pattern_t * p);
     int _bnfa_opt_nfa();
     int _bnfa_build_nfa();
+    int _expand_sparse_failure_transitions();
+    bnfa_state_index_t _bnfa_list_get_next_state_follow_failure(
+        bnfa_state_index_t state,
+        unsigned char input);
     int _bnfa_conv_list_to_csparse_array();
     int _resolve_full_row_failure_transitions();
     int _build_failureless_transition_cache(const std::vector<bnfa_state_index_t>& state_indexes);
@@ -719,7 +736,7 @@ AhoCorasickSearch::_bnfa_search_csparse_nfa_q(RAIterator begin, RAIterator Tend,
 #ifdef AHO_CORASICK_SEARCH_STATS
         ++search_stats_.match_state_checks;
 #endif
-        if (sindex && isMatchState(transList[sindex + 1]) )
+        if (sindex && isMatchState(transList[sindex + 1]))
         {
 #ifdef AHO_CORASICK_SEARCH_STATS
             ++search_stats_.match_state_hits;
@@ -818,7 +835,7 @@ AhoCorasickSearch::_bnfa_search_csparse_nfa_case(RAIterator begin, RAIterator Te
 #ifdef AHO_CORASICK_SEARCH_STATS
         ++search_stats_.match_state_checks;
 #endif
-        if (sindex && isMatchState(transList[sindex + 1]) )
+        if (sindex && isMatchState(transList[sindex + 1]))
         {
 #ifdef AHO_CORASICK_SEARCH_STATS
             ++search_stats_.match_state_hits;
@@ -979,7 +996,13 @@ AhoCorasickSearch::_bnfa_get_next_state_csparse_nfa(
 #endif
 #if AHO_CORASICK_FAILURELESS_FULL_ROWS
             bnfa_state_index_t idx = fullGetTransitionState(pcs[1 + input]);
-            if (sindex == 0)
+            if (sindex != 0)
+            {
+#ifdef AHO_CORASICK_SEARCH_STATS
+                ++stats->full_non_root_hits;
+#endif
+            }
+            else
             {
 #ifdef AHO_CORASICK_SEARCH_STATS
                 ++stats->full_root_transitions;
@@ -987,12 +1010,6 @@ AhoCorasickSearch::_bnfa_get_next_state_csparse_nfa(
                 {
                     ++stats->full_root_zero_transitions;
                 }
-#endif
-            }
-            else
-            {
-#ifdef AHO_CORASICK_SEARCH_STATS
-                ++stats->full_non_root_hits;
 #endif
             }
             return idx;

--- a/src/aho_corasick.h
+++ b/src/aho_corasick.h
@@ -73,6 +73,18 @@
 // define this to have more than 16 millions states
 #define BNFA_STATE_64BITS
 
+#ifndef AHO_CORASICK_FULL_ROW_MIN_TRANSITIONS
+#define AHO_CORASICK_FULL_ROW_MIN_TRANSITIONS 4
+#endif
+
+#ifndef AHO_CORASICK_FAILURELESS_CACHE_MAX_STATES
+#define AHO_CORASICK_FAILURELESS_CACHE_MAX_STATES 0
+#endif
+
+#ifndef AHO_CORASICK_FAILURELESS_FULL_ROWS
+#define AHO_CORASICK_FAILURELESS_FULL_ROWS 1
+#endif
+
 namespace textsearch {
 
 
@@ -115,6 +127,8 @@ public:
         uint64_t sparse_binary_hits = 0;
         uint64_t sparse_binary_misses = 0;
         uint64_t failure_transitions = 0;
+        uint64_t failureless_cache_hits = 0;
+        uint64_t failureless_cache_misses = 0;
         uint64_t match_state_checks = 0;
         uint64_t match_state_hits = 0;
         uint64_t match_candidates = 0;
@@ -169,7 +183,24 @@ public:
         bnfa_state_index_t sindex,
         bnfa_state_index_t* current_state);
 
-    int getPatternCount();
+    int getPatternCount() const;
+    bnfa_state_index_t getStateCount() const;
+    size_t getTransitionMemoryBytes() const;
+    size_t getFailurelessCacheMemoryBytes() const;
+    size_t getFailurelessCacheStateCount() const;
+    size_t getTotalMemoryBytes() const;
+    static constexpr unsigned getFullRowMinTransitions()
+    {
+        return BNFA_FULL_ROW_MIN_TRANSITIONS;
+    }
+    static constexpr size_t getFailurelessCacheMaxStates()
+    {
+        return BNFA_FAILURELESS_CACHE_MAX_STATES;
+    }
+    static constexpr bool hasFailurelessFullRows()
+    {
+        return BNFA_FAILURELESS_FULL_ROWS;
+    }
 
     void print(); /* prints the nfa states-verbose!! */
     void printInfo(); /* print info on this search engine */
@@ -225,6 +256,16 @@ private:
 
     static constexpr unsigned BNFA_SPARSE_LINEAR_SEARCH_LIMIT = 6;
     static constexpr unsigned BNFA_MAX_ALPHABET_SIZE = 256;
+    static constexpr unsigned BNFA_FULL_ROW_MIN_TRANSITIONS =
+        AHO_CORASICK_FULL_ROW_MIN_TRANSITIONS;
+    static constexpr size_t BNFA_FAILURELESS_CACHE_MAX_STATES =
+        AHO_CORASICK_FAILURELESS_CACHE_MAX_STATES;
+    static constexpr bool BNFA_FAILURELESS_FULL_ROWS =
+        AHO_CORASICK_FAILURELESS_FULL_ROWS != 0;
+    static_assert(
+        BNFA_FULL_ROW_MIN_TRANSITIONS >= 1 &&
+            BNFA_FULL_ROW_MIN_TRANSITIONS <= BNFA_SPARSE_MAX_ROW_TRANSITIONS + 1,
+        "AHO_CORASICK_FULL_ROW_MIN_TRANSITIONS must be between 1 and 64");
 
  
     /*
@@ -362,6 +403,8 @@ private:
     std::vector<bnfa_state_index_t> bnfaFailState;
 
     std::vector<bnfa_state_t> bnfaTransList;
+    std::vector<size_t> failureless_cache_offsets_;
+    std::vector<bnfa_state_index_t> failureless_transition_cache_;
     int                bnfaForceFullZeroState;
 
     std::vector<std::unique_ptr<bnfa_pattern_t>> pattern_storage_;
@@ -376,6 +419,7 @@ private:
     size_t 			   pat_memory;
     size_t 			   list_memory;
     size_t 			   nextstate_memory;
+    size_t             failureless_cache_memory;
     size_t 			   failstate_memory;
     size_t 			   matchlist_memory;
     character_functor toupper_functor;
@@ -408,6 +452,8 @@ private:
     int _bnfa_opt_nfa();
     int _bnfa_build_nfa();
     int _bnfa_conv_list_to_csparse_array();
+    int _resolve_full_row_failure_transitions();
+    int _build_failureless_transition_cache(const std::vector<bnfa_state_index_t>& state_indexes);
     void _reset_compiled_state();
     bnfa_trans_node_t* _make_transition_node();
     bnfa_match_node_t* _make_match_node();
@@ -425,9 +471,30 @@ private:
     static size_t _bnfa_conv_node_to_full(bnfa_trans_node_t* t, bnfa_state_t * full);
     
     static int KcontainsJ(bnfa_trans_node_t * tk, bnfa_trans_node_t *tj);
+
+    static inline bool shouldUseFullFormatForRow(
+        bnfa_state_index_t state,
+        unsigned transition_count,
+        int force_full_zero_state)
+    {
+        return (state == 0 && force_full_zero_state) ||
+            transition_count >= BNFA_FULL_ROW_MIN_TRANSITIONS ||
+            transition_count > BNFA_SPARSE_MAX_ROW_TRANSITIONS;
+    }
     
     static FORCE_INLINE bnfa_state_index_t _bnfa_get_next_state_csparse_nfa(
         bnfa_state_t * pcx,
+        bnfa_state_index_t sindex,
+        unsigned input
+#ifdef AHO_CORASICK_SEARCH_STATS
+        , SearchStats* stats
+#endif
+        );
+
+    static FORCE_INLINE bnfa_state_index_t _bnfa_get_next_state_failureless_nfa(
+        bnfa_state_t * pcx,
+        const size_t* failureless_cache_offsets,
+        const bnfa_state_index_t* failureless_transition_cache,
         bnfa_state_index_t sindex,
         unsigned input
 #ifdef AHO_CORASICK_SEARCH_STATS
@@ -612,6 +679,10 @@ AhoCorasickSearch::_bnfa_search_csparse_nfa_q(RAIterator begin, RAIterator Tend,
 
     bnfa_match_node_t ** MatchList = bnfaMatchList.data();
     bnfa_state_t       * transList = bnfaTransList.data();
+#if AHO_CORASICK_FAILURELESS_CACHE_MAX_STATES > 0
+    const size_t* failureless_cache_offsets = failureless_cache_offsets_.data();
+    const bnfa_state_index_t* failureless_transition_cache = failureless_transition_cache_.data();
+#endif
     bnfa_state_index_t   last_sindex;
     unsigned int nfound = 0;
 
@@ -622,6 +693,18 @@ AhoCorasickSearch::_bnfa_search_csparse_nfa_q(RAIterator begin, RAIterator Tend,
         last_sindex = sindex;
 
         /* Transition to next state index */
+#if AHO_CORASICK_FAILURELESS_CACHE_MAX_STATES > 0
+        sindex = _bnfa_get_next_state_failureless_nfa(
+            transList,
+            failureless_cache_offsets,
+            failureless_transition_cache,
+            sindex,
+            static_cast<unsigned char>(*T)
+#ifdef AHO_CORASICK_SEARCH_STATS
+            , &search_stats_
+#endif
+            );
+#else
         sindex = _bnfa_get_next_state_csparse_nfa(
             transList,
             sindex,
@@ -630,6 +713,7 @@ AhoCorasickSearch::_bnfa_search_csparse_nfa_q(RAIterator begin, RAIterator Tend,
             , &search_stats_
 #endif
             );
+#endif
 
         /* Log matches in this state - if any */
 #ifdef AHO_CORASICK_SEARCH_STATS
@@ -696,6 +780,10 @@ AhoCorasickSearch::_bnfa_search_csparse_nfa_case(RAIterator begin, RAIterator Te
     bnfa_match_node_t ** MatchList = bnfaMatchList.data();
     bnfa_pattern_t     * patrn;
     bnfa_state_t       * transList = bnfaTransList.data();
+#if AHO_CORASICK_FAILURELESS_CACHE_MAX_STATES > 0
+    const size_t* failureless_cache_offsets = failureless_cache_offsets_.data();
+    const bnfa_state_index_t* failureless_transition_cache = failureless_transition_cache_.data();
+#endif
     unsigned             nfound = 0;
     bnfa_state_index_t             last_match = LAST_STATE_INIT;
     bnfa_state_index_t             last_match_saved = LAST_STATE_INIT;
@@ -704,6 +792,18 @@ AhoCorasickSearch::_bnfa_search_csparse_nfa_case(RAIterator begin, RAIterator Te
     for (; T<Tend; ++T)
     {
         /* Transition to next state index */
+#if AHO_CORASICK_FAILURELESS_CACHE_MAX_STATES > 0
+        sindex = _bnfa_get_next_state_failureless_nfa(
+            transList,
+            failureless_cache_offsets,
+            failureless_transition_cache,
+            sindex,
+            static_cast<unsigned char>(*T)
+#ifdef AHO_CORASICK_SEARCH_STATS
+            , &search_stats_
+#endif
+            );
+#else
         sindex = _bnfa_get_next_state_csparse_nfa(
             transList,
             sindex,
@@ -712,6 +812,7 @@ AhoCorasickSearch::_bnfa_search_csparse_nfa_case(RAIterator begin, RAIterator Te
             , &search_stats_
 #endif
             );
+#endif
 
         /* Log matches in this state - if any */
 #ifdef AHO_CORASICK_SEARCH_STATS
@@ -876,6 +977,26 @@ AhoCorasickSearch::_bnfa_get_next_state_csparse_nfa(
 #ifdef AHO_CORASICK_SEARCH_STATS
             ++stats->full_row_visits;
 #endif
+#if AHO_CORASICK_FAILURELESS_FULL_ROWS
+            bnfa_state_index_t idx = fullGetTransitionState(pcs[1 + input]);
+            if (sindex == 0)
+            {
+#ifdef AHO_CORASICK_SEARCH_STATS
+                ++stats->full_root_transitions;
+                if (idx == 0)
+                {
+                    ++stats->full_root_zero_transitions;
+                }
+#endif
+            }
+            else
+            {
+#ifdef AHO_CORASICK_SEARCH_STATS
+                ++stats->full_non_root_hits;
+#endif
+            }
+            return idx;
+#else
             if (sindex == 0)
             {
                 bnfa_state_index_t idx = fullGetTransitionState(pcs[1 + input]);
@@ -902,6 +1023,7 @@ AhoCorasickSearch::_bnfa_get_next_state_csparse_nfa(
                 ++stats->full_non_root_misses;
 #endif
             }
+#endif
         }
         else // Sparse
         {
@@ -965,6 +1087,43 @@ AhoCorasickSearch::_bnfa_get_next_state_csparse_nfa(
 #endif
         sindex = getFailureState(pcs[0]);
     }
+}
+
+FORCE_INLINE
+AhoCorasickSearch::bnfa_state_index_t
+AhoCorasickSearch::_bnfa_get_next_state_failureless_nfa(
+    bnfa_state_t * pcx,
+    const size_t* failureless_cache_offsets,
+    const bnfa_state_index_t* failureless_transition_cache,
+    bnfa_state_index_t sindex,
+    unsigned input
+#ifdef AHO_CORASICK_SEARCH_STATS
+    , SearchStats* stats
+#endif
+    )
+{
+    const size_t cache_offset = failureless_cache_offsets[sindex];
+    if (cache_offset != 0)
+    {
+#ifdef AHO_CORASICK_SEARCH_STATS
+        ++stats->transition_calls;
+        ++stats->state_visits;
+        ++stats->failureless_cache_hits;
+#endif
+        return failureless_transition_cache[cache_offset - 1 + input];
+    }
+
+#ifdef AHO_CORASICK_SEARCH_STATS
+    ++stats->failureless_cache_misses;
+#endif
+    return _bnfa_get_next_state_csparse_nfa(
+        pcx,
+        sindex,
+        input
+#ifdef AHO_CORASICK_SEARCH_STATS
+        , stats
+#endif
+        );
 }
 
 }

--- a/src/aho_corasick.h
+++ b/src/aho_corasick.h
@@ -96,6 +96,41 @@ public:
         BNFA_NOCASE        // case-insensitive search
     };
 
+#ifdef AHO_CORASICK_SEARCH_STATS
+    struct SearchStats {
+        uint64_t transition_calls = 0;
+        uint64_t state_visits = 0;
+        uint64_t full_row_visits = 0;
+        uint64_t full_root_transitions = 0;
+        uint64_t full_root_zero_transitions = 0;
+        uint64_t full_non_root_hits = 0;
+        uint64_t full_non_root_misses = 0;
+        uint64_t sparse_row_visits = 0;
+        uint64_t sparse_linear_rows = 0;
+        uint64_t sparse_linear_comparisons = 0;
+        uint64_t sparse_linear_hits = 0;
+        uint64_t sparse_linear_misses = 0;
+        uint64_t sparse_binary_rows = 0;
+        uint64_t sparse_binary_comparisons = 0;
+        uint64_t sparse_binary_hits = 0;
+        uint64_t sparse_binary_misses = 0;
+        uint64_t failure_transitions = 0;
+        uint64_t match_state_checks = 0;
+        uint64_t match_state_hits = 0;
+        uint64_t match_candidates = 0;
+    };
+
+    void resetSearchStats()
+    {
+        search_stats_ = SearchStats {};
+    }
+
+    SearchStats getSearchStats() const
+    {
+        return search_stats_;
+    }
+#endif
+
     void setCase(bnfa_case flag);
 
 
@@ -333,6 +368,10 @@ private:
     std::vector<std::unique_ptr<bnfa_trans_node_t>> transition_node_storage_;
     std::vector<std::unique_ptr<bnfa_match_node_t>> match_node_storage_;
 
+#ifdef AHO_CORASICK_SEARCH_STATS
+    SearchStats search_stats_;
+#endif
+
     size_t 			   bnfa_memory;
     size_t 			   pat_memory;
     size_t 			   list_memory;
@@ -387,7 +426,14 @@ private:
     
     static int KcontainsJ(bnfa_trans_node_t * tk, bnfa_trans_node_t *tj);
     
-    static FORCE_INLINE bnfa_state_index_t _bnfa_get_next_state_csparse_nfa(bnfa_state_t * pcx, bnfa_state_index_t sindex, unsigned  input);
+    static FORCE_INLINE bnfa_state_index_t _bnfa_get_next_state_csparse_nfa(
+        bnfa_state_t * pcx,
+        bnfa_state_index_t sindex,
+        unsigned input
+#ifdef AHO_CORASICK_SEARCH_STATS
+        , SearchStats* stats
+#endif
+        );
 
 
     static
@@ -446,7 +492,14 @@ private:
         return (state & BNFA_SPARSE_MATCH_BIT)!=0;
     }
 
-    static inline int _bnfa_binearch(bnfa_state_t * a, int a_len, bnfa_state_t val)
+    static inline int _bnfa_binearch(
+        bnfa_state_t * a,
+        int a_len,
+        bnfa_state_t val
+#ifdef AHO_CORASICK_SEARCH_STATS
+        , SearchStats* stats
+#endif
+        )
     {
         int m, l, r;
         bnfa_state_t c;
@@ -456,6 +509,9 @@ private:
         {
             m = (r + l) >> 1;
             c = a[m] >> BNFA_SPARSE_VALUE_SHIFT;
+#ifdef AHO_CORASICK_SEARCH_STATS
+            ++stats->sparse_binary_comparisons;
+#endif
             if (val == c)
             {
                 return m;
@@ -566,11 +622,24 @@ AhoCorasickSearch::_bnfa_search_csparse_nfa_q(RAIterator begin, RAIterator Tend,
         last_sindex = sindex;
 
         /* Transition to next state index */
-        sindex = _bnfa_get_next_state_csparse_nfa(transList, sindex, static_cast<unsigned char>(*T));
+        sindex = _bnfa_get_next_state_csparse_nfa(
+            transList,
+            sindex,
+            static_cast<unsigned char>(*T)
+#ifdef AHO_CORASICK_SEARCH_STATS
+            , &search_stats_
+#endif
+            );
 
         /* Log matches in this state - if any */
+#ifdef AHO_CORASICK_SEARCH_STATS
+        ++search_stats_.match_state_checks;
+#endif
         if (sindex && isMatchState(transList[sindex + 1]) )
         {
+#ifdef AHO_CORASICK_SEARCH_STATS
+            ++search_stats_.match_state_hits;
+#endif
             /* Test for same as last state */
             if (sindex == last_sindex)
                 continue;
@@ -592,6 +661,9 @@ AhoCorasickSearch::_bnfa_search_csparse_nfa_q(RAIterator begin, RAIterator Tend,
                 else
                     index = raw_index;
                 nfound++;
+#ifdef AHO_CORASICK_SEARCH_STATS
+                ++search_stats_.match_candidates;
+#endif
                 if (_add_queue(mlist, index))
                 {
                     if (_process_queue(match_functor, userdata,begin))
@@ -632,11 +704,24 @@ AhoCorasickSearch::_bnfa_search_csparse_nfa_case(RAIterator begin, RAIterator Te
     for (; T<Tend; ++T)
     {
         /* Transition to next state index */
-        sindex = _bnfa_get_next_state_csparse_nfa(transList, sindex, static_cast<unsigned char>(*T));
+        sindex = _bnfa_get_next_state_csparse_nfa(
+            transList,
+            sindex,
+            static_cast<unsigned char>(*T)
+#ifdef AHO_CORASICK_SEARCH_STATS
+            , &search_stats_
+#endif
+            );
 
         /* Log matches in this state - if any */
+#ifdef AHO_CORASICK_SEARCH_STATS
+        ++search_stats_.match_state_checks;
+#endif
         if (sindex && isMatchState(transList[sindex + 1]) )
         {
+#ifdef AHO_CORASICK_SEARCH_STATS
+            ++search_stats_.match_state_hits;
+#endif
             if (sindex == last_match)
                 continue;
 
@@ -655,6 +740,9 @@ AhoCorasickSearch::_bnfa_search_csparse_nfa_case(RAIterator begin, RAIterator Te
                 else
                     index = raw_index;
                 nfound++;
+#ifdef AHO_CORASICK_SEARCH_STATS
+                ++search_stats_.match_candidates;
+#endif
                 /* Don't do anything specific for case sensitive patterns and not,
                 * since that will be covered by the rule tree itself.  Each tree
                 * might have both case sensitive & case insensitive patterns.
@@ -762,6 +850,9 @@ AhoCorasickSearch::_bnfa_get_next_state_csparse_nfa(
     bnfa_state_t * pcx,
     bnfa_state_index_t sindex,
     unsigned  input
+#ifdef AHO_CORASICK_SEARCH_STATS
+    , SearchStats* stats
+#endif
     )
 {
     unsigned k;
@@ -769,49 +860,109 @@ AhoCorasickSearch::_bnfa_get_next_state_csparse_nfa(
     int index;
     bnfa_state_t * pcs;
 
+#ifdef AHO_CORASICK_SEARCH_STATS
+    ++stats->transition_calls;
+#endif
+
     for (;;)
     {
+#ifdef AHO_CORASICK_SEARCH_STATS
+        ++stats->state_visits;
+#endif
         pcs = pcx + sindex + 1; /* skip state-id == 1st word */
 
         if (isFullFormat(pcs[0]))
         {
+#ifdef AHO_CORASICK_SEARCH_STATS
+            ++stats->full_row_visits;
+#endif
             if (sindex == 0)
             {
-                return fullGetTransitionState(pcs[1 + input]);
+                bnfa_state_index_t idx = fullGetTransitionState(pcs[1 + input]);
+#ifdef AHO_CORASICK_SEARCH_STATS
+                ++stats->full_root_transitions;
+                if (idx == 0)
+                {
+                    ++stats->full_root_zero_transitions;
+                }
+#endif
+                return idx;
             }
             else
             {
                 bnfa_state_index_t idx = fullGetTransitionState(pcs[1 + input]);
                 if (idx != 0)
+                {
+#ifdef AHO_CORASICK_SEARCH_STATS
+                    ++stats->full_non_root_hits;
+#endif
                     return idx;
+                }
+#ifdef AHO_CORASICK_SEARCH_STATS
+                ++stats->full_non_root_misses;
+#endif
             }
         }
         else // Sparse
         {
+#ifdef AHO_CORASICK_SEARCH_STATS
+            ++stats->sparse_row_visits;
+#endif
             nc = sparseGetNumberOfTransitions(pcs[0]);
             if (nc > BNFA_SPARSE_LINEAR_SEARCH_LIMIT)
             {
+#ifdef AHO_CORASICK_SEARCH_STATS
+                ++stats->sparse_binary_rows;
+#endif
                 /* binary search... */
-                index = _bnfa_binearch(pcs + 1, nc, input);
+                index = _bnfa_binearch(
+                    pcs + 1,
+                    nc,
+                    input
+#ifdef AHO_CORASICK_SEARCH_STATS
+                    , stats
+#endif
+                    );
                 if (index >= 0)
                 {
+#ifdef AHO_CORASICK_SEARCH_STATS
+                    ++stats->sparse_binary_hits;
+#endif
                     return sparseGetTransitionState(pcs[index + 1]);
                 }
+#ifdef AHO_CORASICK_SEARCH_STATS
+                ++stats->sparse_binary_misses;
+#endif
             }
             else
             {
+#ifdef AHO_CORASICK_SEARCH_STATS
+                ++stats->sparse_linear_rows;
+#endif
                 /* linear search... */
                 for (k = 0; k < nc; k++)
                 {
+#ifdef AHO_CORASICK_SEARCH_STATS
+                    ++stats->sparse_linear_comparisons;
+#endif
                     if ((pcs[k + 1] >> BNFA_SPARSE_VALUE_SHIFT) == input)
                     {
+#ifdef AHO_CORASICK_SEARCH_STATS
+                        ++stats->sparse_linear_hits;
+#endif
                         return sparseGetTransitionState(pcs[k + 1]);
                     }
                 }
+#ifdef AHO_CORASICK_SEARCH_STATS
+                ++stats->sparse_linear_misses;
+#endif
             }
         }
 
         /* no transition found ... get the failure state and try again  */
+#ifdef AHO_CORASICK_SEARCH_STATS
+        ++stats->failure_transitions;
+#endif
         sindex = getFailureState(pcs[0]);
     }
 }

--- a/tests/test_basic.cpp
+++ b/tests/test_basic.cpp
@@ -1,7 +1,7 @@
 #include "aho_corasick.h"
 #include <algorithm>
 #include <any>
-#include <cassert>
+#include <cstdlib>
 #include <string>
 #include <utility>
 #include <vector>
@@ -40,12 +40,18 @@ bool has_match(const std::vector<IdentifiedMatch>& matches, const IdentifiedMatc
     return std::find(matches.begin(), matches.end(), expected) != matches.end();
 }
 
+void require(bool condition) {
+    if (!condition) {
+        std::abort();
+    }
+}
+
 void add_pattern(
     AhoCorasickSearch& ac,
     const std::string& pattern,
     bool nocase = false,
     AhoCorasickSearch::any_t userdata = nullptr) {
-    assert(ac.addPattern(pattern.begin(), pattern.end(), nocase, userdata) == 0);
+    require(ac.addPattern(pattern.begin(), pattern.end(), nocase, userdata) == 0);
 }
 
 } // namespace
@@ -55,53 +61,53 @@ int main() {
 
     const std::string pattern = "needle";
     add_pattern(ac, pattern);
-    assert(ac.compile() == 0);
+    require(ac.compile() == 0);
 
     const std::string text = "haystack needle haystack";
     std::vector<int> matches;
     AhoCorasickSearch::bnfa_state_index_t state = 0;
     ac.search(text.begin(), text.end(), collect_match, &matches, 0, &state);
 
-    assert(matches.size() == 1);
-    assert(matches[0] == 9);
+    require(matches.size() == 1);
+    require(matches[0] == 9);
 
     matches.clear();
     ac.search(text.begin(), text.end(), collect_match, &matches, 0, nullptr);
-    assert(matches.size() == 1);
-    assert(matches[0] == 9);
+    require(matches.size() == 1);
+    require(matches[0] == 9);
 
     AhoCorasickSearch hello_search;
     const std::string hello = "hello";
     add_pattern(hello_search, hello);
-    assert(hello_search.compile() == 0);
+    require(hello_search.compile() == 0);
 
     const std::string sentence = "say hello to the world";
     int count = 0;
     state = 0;
     hello_search.search(sentence.begin(), sentence.end(), count_match, &count, 0, &state);
-    assert(count == 1);
+    require(count == 1);
 
     AhoCorasickSearch no_case_search(AhoCorasickSearch::bnfa_case::BNFA_NOCASE);
     add_pattern(no_case_search, "Needle");
-    assert(no_case_search.compile() == 0);
+    require(no_case_search.compile() == 0);
 
     const std::string mixed_case_text = "xx nEeDlE";
     matches.clear();
     state = 0;
     no_case_search.search(mixed_case_text.begin(), mixed_case_text.end(), collect_match, &matches, 0, &state);
-    assert(matches.size() == 1);
-    assert(matches[0] == 3);
+    require(matches.size() == 1);
+    require(matches[0] == 3);
 
     AhoCorasickSearch per_pattern_case_search(AhoCorasickSearch::bnfa_case::BNFA_PER_PAT_CASE);
     add_pattern(per_pattern_case_search, "Needle");
-    assert(per_pattern_case_search.compile() == 0);
+    require(per_pattern_case_search.compile() == 0);
 
     const std::string per_pattern_text = "needle Needle";
     matches.clear();
     state = 0;
     per_pattern_case_search.search(per_pattern_text.begin(), per_pattern_text.end(), collect_match, &matches, 0, &state);
-    assert(matches.size() == 1);
-    assert(matches[0] == 7);
+    require(matches.size() == 1);
+    require(matches[0] == 7);
 
     AhoCorasickSearch sparse_search;
     for (char suffix = 'a'; suffix <= 'g'; ++suffix) {
@@ -109,18 +115,18 @@ int main() {
         sparse_pattern.push_back(suffix);
         add_pattern(sparse_search, sparse_pattern);
     }
-    assert(sparse_search.compile() == 0);
+    require(sparse_search.compile() == 0);
 
     const std::string sparse_text = "px pg";
     matches.clear();
     state = 0;
     sparse_search.search(sparse_text.begin(), sparse_text.end(), collect_match, &matches, 0, &state);
-    assert(matches.size() == 1);
-    assert(matches[0] == 3);
+    require(matches.size() == 1);
+    require(matches[0] == 3);
 
     AhoCorasickSearch streaming_search;
     add_pattern(streaming_search, "needle");
-    assert(streaming_search.compile() == 0);
+    require(streaming_search.compile() == 0);
 
     const std::string first_chunk = "xx nee";
     const std::string second_chunk = "dle yy";
@@ -128,12 +134,12 @@ int main() {
     state = 0;
     streaming_search.search(first_chunk.begin(), first_chunk.end(), count_match, &count, 0, &state);
     streaming_search.search(second_chunk.begin(), second_chunk.end(), count_match, &count, 0, &state);
-    assert(count == 1);
+    require(count == 1);
 
     AhoCorasickSearch split_per_pattern_case_search(AhoCorasickSearch::bnfa_case::BNFA_PER_PAT_CASE);
     std::vector<char> split_pattern = {'a', 'a', 'a', 'a', 'a', 'a'};
-    assert(split_per_pattern_case_search.addPattern(split_pattern.begin(), split_pattern.end(), false, nullptr) == 0);
-    assert(split_per_pattern_case_search.compile() == 0);
+    require(split_per_pattern_case_search.addPattern(split_pattern.begin(), split_pattern.end(), false, nullptr) == 0);
+    require(split_per_pattern_case_search.compile() == 0);
 
     std::vector<char> split_first_chunk = {'a', 'a', 'a'};
     std::vector<char> split_second_chunk = {'a', 'a', 'a'};
@@ -143,46 +149,46 @@ int main() {
         split_first_chunk.begin(), split_first_chunk.end(), count_match, &count, 0, &state);
     split_per_pattern_case_search.search(
         split_second_chunk.begin(), split_second_chunk.end(), count_match, &count, 0, &state);
-    assert(count == 0);
+    require(count == 0);
 
     AhoCorasickSearch split_per_pattern_nocase_search(AhoCorasickSearch::bnfa_case::BNFA_PER_PAT_CASE);
     add_pattern(split_per_pattern_nocase_search, "Needle", true);
-    assert(split_per_pattern_nocase_search.compile() == 0);
+    require(split_per_pattern_nocase_search.compile() == 0);
 
     count = 0;
     state = 0;
     split_per_pattern_nocase_search.search(first_chunk.begin(), first_chunk.end(), count_match, &count, 0, &state);
     split_per_pattern_nocase_search.search(second_chunk.begin(), second_chunk.end(), count_match, &count, 0, &state);
-    assert(count == 1);
+    require(count == 1);
 
     AhoCorasickSearch optimized_search;
     optimized_search.setOptimizeFailureStates(true);
     add_pattern(optimized_search, "he");
     add_pattern(optimized_search, "hers");
-    assert(optimized_search.compile() == 0);
+    require(optimized_search.compile() == 0);
 
     const std::string optimized_text = "hers";
     count = 0;
     state = 0;
     optimized_search.search(optimized_text.begin(), optimized_text.end(), count_match, &count, 0, &state);
-    assert(count == 2);
+    require(count == 2);
 
     AhoCorasickSearch terminating_search;
     add_pattern(terminating_search, "a");
-    assert(terminating_search.compile() == 0);
+    require(terminating_search.compile() == 0);
 
     const std::string repeated_text = "aaa";
     matches.clear();
     state = 0;
-    assert(terminating_search.search(
+    require(terminating_search.search(
                repeated_text.begin(), repeated_text.end(), stop_after_first_match, &matches, 0, &state) == 1);
-    assert(matches.size() == 1);
+    require(matches.size() == 1);
 
     AhoCorasickSearch overlapping_search;
     add_pattern(overlapping_search, "he", false, 1);
     add_pattern(overlapping_search, "she", false, 2);
     add_pattern(overlapping_search, "hers", false, 3);
-    assert(overlapping_search.compile() == 0);
+    require(overlapping_search.compile() == 0);
 
     const std::string overlapping_text = "ushers";
     std::vector<IdentifiedMatch> identified_matches;
@@ -194,17 +200,17 @@ int main() {
         &identified_matches,
         0,
         &state);
-    assert(identified_matches.size() == 3);
-    assert(has_match(identified_matches, {1, 2}));
-    assert(has_match(identified_matches, {2, 1}));
-    assert(has_match(identified_matches, {3, 2}));
+    require(identified_matches.size() == 3);
+    require(has_match(identified_matches, {1, 2}));
+    require(has_match(identified_matches, {2, 1}));
+    require(has_match(identified_matches, {3, 2}));
 
     AhoCorasickSearch recompiled_search;
     add_pattern(recompiled_search, "one", false, 1);
-    assert(recompiled_search.compile() == 0);
-    assert(recompiled_search.compile() == 0);
+    require(recompiled_search.compile() == 0);
+    require(recompiled_search.compile() == 0);
     add_pattern(recompiled_search, "two", false, 2);
-    assert(recompiled_search.compile() == 0);
+    require(recompiled_search.compile() == 0);
 
     const std::string recompiled_text = "one two";
     identified_matches.clear();
@@ -216,9 +222,9 @@ int main() {
         &identified_matches,
         0,
         &state);
-    assert(identified_matches.size() == 2);
-    assert(has_match(identified_matches, {1, 0}));
-    assert(has_match(identified_matches, {2, 4}));
+    require(identified_matches.size() == 2);
+    require(has_match(identified_matches, {1, 0}));
+    require(has_match(identified_matches, {2, 4}));
 
     return 0;
 }

--- a/tests/test_python_extension.py
+++ b/tests/test_python_extension.py
@@ -35,6 +35,7 @@ def test_get_automaton_info():
     assert info["total_memory_bytes"] >= info["transition_memory_bytes"]
     assert 1 <= info["full_row_min_transitions"] <= 64
     assert isinstance(info["failureless_full_rows"], bool)
+    assert 0 <= info["sparse_failureless_max_transitions"] <= 63
     assert info["failureless_cache_max_states"] >= 0
 
 

--- a/tests/test_python_extension.py
+++ b/tests/test_python_extension.py
@@ -23,6 +23,21 @@ def test_count_matches():
     assert ac.count_matches("hay needle") == 2
 
 
+def test_get_automaton_info():
+    ac = aho_corasick_search_ext.AhoCorasick(["needle", "hay"])
+
+    info = ac.get_automaton_info()
+    assert info["pattern_count"] == 2
+    assert info["state_count"] > 0
+    assert info["transition_memory_bytes"] > 0
+    assert info["failureless_cache_memory_bytes"] >= 0
+    assert info["failureless_cache_state_count"] >= 0
+    assert info["total_memory_bytes"] >= info["transition_memory_bytes"]
+    assert 1 <= info["full_row_min_transitions"] <= 64
+    assert isinstance(info["failureless_full_rows"], bool)
+    assert info["failureless_cache_max_states"] >= 0
+
+
 def test_search_stats_when_enabled():
     ac = aho_corasick_search_ext.AhoCorasick(["needle", "hay"])
     if not hasattr(ac, "get_search_stats"):
@@ -35,4 +50,6 @@ def test_search_stats_when_enabled():
     assert stats["transition_calls"] == len("hay needle")
     assert stats["match_state_checks"] == len("hay needle")
     assert stats["state_visits"] >= stats["transition_calls"]
+    cache_lookups = stats["failureless_cache_hits"] + stats["failureless_cache_misses"]
+    assert cache_lookups <= stats["transition_calls"]
     assert stats["match_candidates"] == 2

--- a/tests/test_python_extension.py
+++ b/tests/test_python_extension.py
@@ -21,3 +21,18 @@ def test_count_matches():
     ac = aho_corasick_search_ext.AhoCorasick(["needle", "hay"])
 
     assert ac.count_matches("hay needle") == 2
+
+
+def test_search_stats_when_enabled():
+    ac = aho_corasick_search_ext.AhoCorasick(["needle", "hay"])
+    if not hasattr(ac, "get_search_stats"):
+        return
+
+    ac.reset_search_stats()
+    assert ac.count_matches("hay needle") == 2
+
+    stats = ac.get_search_stats()
+    assert stats["transition_calls"] == len("hay needle")
+    assert stats["match_state_checks"] == len("hay needle")
+    assert stats["state_visits"] >= stats["transition_calls"]
+    assert stats["match_candidates"] == 2

--- a/tests/test_python_extension.py
+++ b/tests/test_python_extension.py
@@ -1,0 +1,23 @@
+import aho_corasick_search_ext
+
+
+def test_find_matches_as_indexes():
+    ac = aho_corasick_search_ext.AhoCorasick(["he", "she", "hers"])
+
+    assert sorted(ac.find_matches_as_indexes("ushers")) == [
+        (0, 2, 4),
+        (1, 1, 4),
+        (2, 2, 6),
+    ]
+
+
+def test_find_matches_as_strings():
+    ac = aho_corasick_search_ext.AhoCorasick(["needle", "hay"])
+
+    assert ac.find_matches_as_strings(b"hay needle") == ["hay", "needle"]
+
+
+def test_count_matches():
+    ac = aho_corasick_search_ext.AhoCorasick(["needle", "hay"])
+
+    assert ac.count_matches("hay needle") == 2


### PR DESCRIPTION
## Problem

The search engine needed a native Python interface and a repeatable benchmark/profiling workflow before making further transition-layout changes. The prior implementation also left transition-layout tuning questions unmeasured.

## Approach

- Add a nanobind-based CPython extension in `python/aho_corasick_search_ext.cpp` exposing `AhoCorasick`, `count_matches()`, `find_matches_as_indexes()`, `find_matches_as_strings()`, and automaton metadata.
- Add `examples/python_example.py` as a minimal extension usage example.
- Add optional native search counters behind `ENABLE_SEARCH_STATS` so transition calls, full/sparse visits, failure walks, and match-state checks can be measured from Python.
- Tune transition layout with `FULL_ROW_MIN_TRANSITIONS` and keep failureless full-row resolution enabled by default.
- Add an opt-in bounded sparse failureless expansion via `SPARSE_FAILURELESS_MAX_TRANSITIONS`, documented as experimental and disabled by default.
- Document benchmark process, measurements, rejected alternatives, and tradeoffs in `performance_log.md`.

## Results

The strongest retained improvement remains full-row failure resolution with the tuned full-row threshold. The bounded sparse expansion is kept as an opt-in experiment because it reduces some failure walks but increases sparse-row scan length enough that it is not a default win on the current long benchmark.

Branch hints, native-only compile flag experiments, PGO, and hot-state selective cache work were evaluated and removed or left out of the build surface because they did not produce a reliable timing improvement.

## Risks and Tradeoffs

- The Python extension introduces a new native binding surface and depends on nanobind when `BUILD_PYTHON_EXTENSION=ON`.
- `SPARSE_FAILURELESS_MAX_TRANSITIONS` can increase transition memory and sparse scan cost; it is disabled by default.
- Benchmark results are workload-sensitive, so retained knobs are documented as tunables rather than universal defaults.

## Validation

- `cmake --build build-hot-release -j && ctest --test-dir build-hot-release --output-on-failure`
- `cmake --build build-hot-stats -j && ctest --test-dir build-hot-stats --output-on-failure`
- `git diff --check`
